### PR TITLE
t-distribution Review

### DIFF
--- a/07-inference-for-numerical-responses/02-lesson/07-02-lesson.Rmd
+++ b/07-inference-for-numerical-responses/02-lesson/07-02-lesson.Rmd
@@ -586,7 +586,7 @@ Suppose instead of the mean, we want to estimate the median difference in prices
 First, for the price differences, generate 1000 bootstrap replicates and calculate their medians. Remember, for the test of a single mean you only need to `specify()` a `response` variable. 
 
 ```{r estimate_the_median_difference_in_textbook_prices, exercise=TRUE}
-# Calculate 500 bootstrap medians of diff
+# Calculate 1000 bootstrap medians of diff
 textdiff_med_ci <- textbooks %>%
   sepecify(response = ___) %>%
   generate(reps = ___, type = ___) %>%
@@ -602,7 +602,7 @@ textdiff_med_ci <- textbooks %>%
 </div>
 
 ```{r estimate_the_median_difference_in_textbook_prices-solution}
-# Calculate 500 bootstrap medians of diff
+# Calculate 10000 bootstrap medians of diff
 textdiff_med_ci <- textbooks %>%
   specify(response = diff) %>%
   generate(reps = 1000, type = "bootstrap") %>%
@@ -617,7 +617,7 @@ Then, calculate a 95% confidence interval for the bootstrap median price differe
 # From previous step
 textdiff_med_ci <- textbooks %>%
   specify(response = diff) %>%
-  generate(reps = 500, type = "bootstrap") %>%
+  generate(reps = 1000, type = "bootstrap") %>%
   calculate(stat = "median")
 
 ```

--- a/07-inference-for-numerical-responses/02-lesson/07-02-lesson.Rmd
+++ b/07-inference-for-numerical-responses/02-lesson/07-02-lesson.Rmd
@@ -31,11 +31,14 @@ set.seed(20170801)
 
 acs12_emp <- acs12 %>%
   filter(employment == "employed")
+
+hsb2 <- hsb2 %>% 
+  mutate(diff = read - write)
 ```
 
 ## t-distribution
 
-So far we have discussed inference on numerical data using simulation based methods. When the parameter of interest is the mean (or a difference between two means) and certain conditions are met, we can also use methods based on the central limit theorem for conducting inference.
+So far we have discussed inference on numerical data using simulation based methods. When the parameter of interest is the mean (or a difference between two means) and certain conditions are not violated, we can also use methods based on the Central Limit Theorem for conducting inference.
 
 > - $\sigma$ is unknown (almost always) $\rightarrow$ $\bar{x}~\sim~$ t-distribution
 > - t-distribution is bell shaped but has thicker tails the normal
@@ -55,21 +58,19 @@ This means that under the t distribution observations are more likely to fall 2 
 
 > - Always centered at 0 
 > - Has one parameter: **degrees of freedom** (df) - determines thickness of tails 
->   - As df increases, the t-distribution approaches the normal distribution 
+>   - As df increases, the t-distribution looks more and more like the normal distribution 
 
 ![](images/tDistConvergeToNormalDist.png)
 
-The t distribution is always centered at zero,
+The t-distribution is always centered at zero, and it has one parameter, degrees of freedom, which determines the thickness of its tails.
 
-and it has one parameter, degrees of freedom, which determines the thickness of its tails.
-
-What happens to the shape of the t distribution as the degrees of freedom increases?
+What happens to the shape of the t-distribution as the degrees of freedom increases?
 
 This plot shows a series of bell curves, going from light to dark shades of gray as the degrees of freedom increases. 
 
-We can see that as the degrees of freedom increases, the t distribution approaches the normal distribution.
+We can see that as the degrees of freedom increases, the t-distribution approaches the normal distribution.
 
-This is why you might see in other resources that if the sample size is large enough one can use the normal distribution to approximate the sampling distribution of the mean. Often such statements will be accompanied by a sample size that can be considered large enough for the statement to hold. In this tutorial we will keep things simple and straightforward -- when working with the mean (or difference of means) use the t distribution for central limit theorem based inference.
+This is why you might see in other resources that if the sample size is "large enough" one can use the normal distribution to approximate the sampling distribution of the mean. Often such statements will be accompanied by a sample size that can be considered "large enough" for the statement to hold. In this tutorial we will keep things simple and straightforward -- when working with the mean (or difference of means) use the t-distribution for Central Limit Theorem based inference.
 
 Now let's try some examples.
 
@@ -78,18 +79,20 @@ Now let's try some examples.
 
 ```{r quiz_1}
 question("Which of the following describes best why we might need to use the t-distribution for inference?", 
-           correct = "Great job! You're a t pro!", 
+           correct = "Great job! You're a t-pro!", 
            allow_retry = TRUE,
-    answer("population distribution is not known", message = "No. If you don't know anything about the population distribution, the t-distribution won't help you."),
-    answer("population standard deviation is unknown", correct = TRUE),
-    answer("sample is not random", message = "No. If your sample is not random, a t-distribution is not appropriate."),
-    answer("sample is not representative of the population", message = "Sorry. If your sample is not representative of the population, you shouldn't use it to infer things about that population.")
+    answer("When the population distribution is not known", message = "No. If you don't know anything about the population distribution, the t-distribution won't help you."),
+    answer("When the population standard deviation is unknown", correct = TRUE),
+    answer("When the sample is not random", message = "No. If your sample is not random, a t-distribution is not appropriate."),
+    answer("When the sample is not representative of the population", message = "Sorry. If your sample is not representative of the population, you shouldn't use it to infer things about that population.")
   )
 ```
 
 ### Probabilities under the t-distribution
 
-We can use the `pt()` function to find probabilities under the t-distribution. For a given cutoff value `q` and a given degrees of freedom `df`, `pt(q, df)` gives us the probability under the t-distribution with `df` degrees of freedom for values of `t` less than `q`. In other words, $P(t_{df} < T)$ = `pt(q = T, df)`.
+We can use the `pt()` function to find probabilities under the t-distribution. For a given cutoff value `q` and a given degrees of freedom `df`, `pt(q, df)` gives us the probability under the t-distribution with `df` degrees of freedom for values of $t$ less than `q`. In other words, $P(t_{df} < T)$ = `pt(q = T, df)`.
+
+In the exercise below, 
 
 - Find the probability under the t-distribution with 10 degrees of freedom below $T = 3$.
 - Find the probability under the t-distribution with 10 degrees of freedom above $T = 3$.
@@ -141,13 +144,14 @@ Great job! Do your findings agree with the statement that as the degrees of free
 
 ### Cutoffs under the t-distribution
 
-We can use the `qt()` function to find cutoffs under the t-distribution. For a given probability `p` and a given degrees of freedom `df`, `qt(p, df)` gives us the cutoff value for the t-distribution with `df` degrees of freedom for which the probability under the curve is `p`. In other words, if $P(t_{df} < T) = p$, then $T$ = `qt(p, df)`. For example, if $T$ corresponds to the 95th percentile of a distribution, $p = 0.95$. The "middle 95%" means from `p = 0.025` to `p = 0.975`.
+We can use the `qt()` function to find cutoffs under the t-distribution. For a given probability `p` and a given degrees of freedom `df`, `qt(p, df)` gives us the cutoff value for the t-distribution with `df` degrees of freedom for which the probability under the curve is `p`. In other words, if $P(t_{df} < T) = p$, then $T$ = `qt(p, df)`. For example, if $T$ corresponds to the 95th percentile of a distribution, $p = 0.95$. The "middle 95%" is between percentiles `p = 0.025` and `p = 0.975`.
 
+In the exercise below, 
 
 - Find the 95th percentile of the t-distribution with 10 degrees of freedom.
 - Find the cutoff value that bounds the upper end of the middle 95th percent of the t-distribution with 10 degrees of freedom.
 - Find the cutoff value that bounds the upper end of the middle 95th percent of the t-distribution with 100 degrees of freedom.
-- *How do the last values probabilities compare? Based on your findings, is the middle 95% of the t-distribution wider for lower or higher degrees of freedom?*
+- *How do the last percentiles compare? Based on your findings, is the middle 95% of the t-distribution wider for lower or higher degrees of freedom?*
 
 
 ```{r t-distribution-cutoffs, exercise=TRUE}
@@ -190,7 +194,6 @@ y < z
 
 ## Estimating with the t-interval
 
-
 In this lesson we learn how to construct confidence intervals for a population mean using the t-distribution.
 
 ### Quantifying variability of sample means
@@ -202,7 +205,7 @@ In this lesson we learn how to construct confidence intervals for a population m
 > - Simulate with bootstrapping
 > - Approximate with Central Limit Theorem
 
-Let's start with a motivating question:  Suppose among a random sample of 100 people 13 are left handed. If you were to select another random sample of 100, would you be surprised if only 12 are left handed? Probably not... What about 15? Again, probably not... or 30? Hard to tell... What about 1 or 90? We can probably agree tat these look quite unlikely.
+Let's start with a motivating question:  Suppose among a random sample of 100 people 13 are left handed. If you were to select another random sample of 100, would you be surprised if only 12 are left handed? Probably not... What about 15? Again, probably not... or 30? Hard to tell... What about 1 or 90? We can probably agree that these look quite unlikely.
 
 Clearly, we need a way to quantify how much variability is expected between samples.
 
@@ -218,19 +221,17 @@ Another approach is to use theory, or specifically the Central Limit Theorem, to
 > - $\sigma$ unknown: 
 >   - $SE = \frac{s}{\sqrt{n}}$ 
 >   - Use $t_{df = n - 1}$ for inference for a mean 
-> - Only true if certain conditions are satisfied... 
+> - Only true if certain conditions are not violated... 
 
 The Central Limit Theorems states the distribution of sample means is nearly normal, centered at the population mean, and with a standard error equal to the population standard deviation divided by the square root of the sample size.
 
-The standard error is defined as the standard deviation of the sampling distribution, which is the distribution of sample means of samples from the original population. Note, this is a theoretical distribution that we in reality can't generate because we don't have the luxury of going back to the original population to take new samples. It's similar in spirit to the bootstrap distribution but it's different as the samples are not resampled from the original sample, but instead the population.
+The standard error is defined as the standard deviation of the sampling distribution, which is the distribution of sample means of samples from the original population. Note, this is a theoretical distribution that we in reality can't generate because we don't have the luxury of going back to the original population to take new samples. It's similar in spirit to the bootstrap distribution but it's different as the samples are not resampled from the original sample, but instead the population. The standard error from the bootstrap distribution can be thought of as an approximation to this *true* standard error of the sampling distribution. 
 
-Also, since the population standard deviation is often unknown, 
-
-in practice, the standard error is estimated by the standard deviation of the sample divided by the square root of the sample size. 
+Since the population standard deviation is often unknown, in practice, the standard error is estimated by the standard deviation of the sample divided by the square root of the sample size. 
 
 And this additional uncertainty introduced by using the sample standard deviation is mitigated by using a t-distribution with degrees of freedom n - 1 since compared to the normal distribution the t-distribution is more conservative with thicker tails.
 
-And as with most theorems, this one also only applies if certain condition are met.
+And as with most theorems, this one also only applies if certain condition are mathematically met. However, it would be incredibly difficult to "prove" that these conditions are mathematically "met," so, instead, we will evaluate the degree to which it appears that these mathematical conditions are violated. 
 
 
 ### Conditions
@@ -245,33 +246,33 @@ Here are the conditions:
 
 First, the observations in our sample should be independent of each other with respect to the response variable. This is difficult to verify.
 
-However if the study employs random sampling and/or random assignment,
+However if the study employs random sampling and/or random assignment, the risk of dependent observations is substantially lower. 
 
-And for studies that employ random sampling without replacement -- which is almost all polls and surveys -- the sample size is less than 10% of the population, we can be fairly certain that the observations in the sample are independent of each other.
+And for studies that employ random sampling without replacement -- which is almost all polls and surveys -- the sample size should be less than 10% of the population. If we know that our sample is less than 10% of the population, it seems more reasonable to assume that the observations in the sample are independent of each other.
 
-Second, the more skewed the original population distribution, the larger a sample size we need. So it's important to plot the distribution of the sample, which is the best window we have into the unknown population, and verify the skewness of the distribution.
-
-
+Second, the more skewed the original population distribution, the larger a sample size we need to have an approximately normal sampling distribution. So it's important to plot the distribution of the sample, which is the best window we have into the unknown population, and verify the skewness of the distribution.
 
 ### Confidence interval for a mean
 
 
-> Estimate the average number of days Americans work extra hours beyond their usual schedule (variable: `moredays`) using data from the 2010 General Social Survey (data: `gss`).
+> Estimate the average number of hours Americans work in their usual schedule (variable: `hours`) using data from the 2010 General Social Survey (data: `gss`).
 
-
-Let's use data from the 2010 General Social Survey to estimate the number of days per month Americans work extra hours beyond their usual schedule. The data are stored in a dataframe called gss and the variable of interest is called moredays.
+Let's use data from the 2010 General Social Survey to estimate the number of hours Americans work during their "typical" schedule. The data are stored in a dataframe called `gss` and the variable of interest is called `hours`.
 
 ### 
 
-> Estimate the average number of days Americans work extra hours beyond their usual schedule (variable: `moredays`) using data from the 2010 General Social Survey (data: `gss`).
+> Estimate the average number of hours Americans work during their "usual" schedule (variable: `hours`) using data from the 2010 General Social Survey (data: `gss`).
 
 ```{r echo=TRUE}
-t.test(gss$moredays, conf.level = 0.95)
+gss %>% 
+  t_test(response = hours,
+         conf_int = TRUE,
+         conf_level = 0.95)
 ```
 
-We can create the confidence interval using the t-dot-test function -- don't worry about the word "test" for now -- by using the variable as the first argument and the confidence level as the second argument.
+We can create the confidence interval using the `t_test()` -- don't worry about the word "test" for now -- by using the variable we're interested in as the `response`, specifying that we are interested in a confidence interval by setting `conf_int` to `TRUE`, and setting the confidence level as 0.95 (or 95%).
 
-The function output has some extraneous information, but what we need is listed right beneath "95 percent confidence interval". Based on this output, we are 95% confident that the average number of days per month Americans work extra hours beyond their usual schedule is 5.27 to 6.15. That's roughly over 25% of work days in a typical month!
+Based on this output, we are 95% confident that the average number of hours per week Americans work in their usual schedule is between 40.1 and 42.7. 
 
 Time to put this into practice.
 
@@ -279,26 +280,29 @@ Time to put this into practice.
 
 Each year since 2005, the US Census Bureau surveys about 3.5 million households with The [American Community Survey](https://www.census.gov/programs-surveys/acs/) (ACS). Data collected from the ACS have been crucial in government and policy decisions, helping to determine the allocation of federal and state funds each year. Data from the 2012 ACS is available in the `acs12` dataset.
 
-When given one argument, `t.test()` tests whether the population mean of its input is different than 0. That is $H\_0: \mu\_{diff} = 0$ and $H\_A: \mu\_{diff} \ne 0$. It also provides a 95% confidence interval.
+By default, when given one argument, `t_test()` tests whether the population mean of its input is different than 0. That is $H_0: \mu_{variable} = 0$ and $H_A: \mu_{variable} \ne 0$. And, as we saw earlier, `t_test()` can also provide a confidence interval for the population mean.
 
-
+In the exercise below, 
 
 - Filter the `acs12` dataset for individuals whose employment status is `"employed"`, and save this new dataset as `acs12_emp`.
-- Use a t-test to construct a 95% confidence interval for the average commute time of Americans.
+- Use `t_test()` to construct a 95% confidence interval for the average commute time of Americans, recorded as the variable `time_to_work`.
 
 ```{r Average_commute_time_of_Americans, exercise=TRUE}
 # Filter for employed respondents
 acs12_emp <- acs12 %>%
-  ___
+  filter(___)
 
 # Construct 95% CI for avg time_to_work
-t.test(___)
+acs12_emp %>% 
+  t_test(response = ___, 
+         conf_int = TRUE, 
+         conf_level = ___)
 ```
 
 <div id="Average_commute_time_of_Americans-hint">
 **Hint:** 
-- Call `filter()` with the condition that `employment` is equal to `"employed"`.
-- Call `t.test()`, passing the `time_to_work` column of `acs12_emp` (and keep the default the confidence level of `0.95`).
+- Call `filter()` with the condition that `employment` is equal to (`==`) `"employed"`.
+- Call `t_test()`, using `time_to_work` as the `response` and using a confidence level of `0.95`.
 </div>
 
 ```{r Average_commute_time_of_Americans-solution}
@@ -307,37 +311,57 @@ acs12_emp <- acs12 %>%
   filter(employment == "employed")
 
 # Construct 95% CI for avg time_to_work
-t.test(acs12_emp$time_to_work)
+acs12_emp %>% 
+  t_test(response = time_to_work, 
+         conf_int = TRUE, 
+         conf_level = 0.95)
 ```
 
 ### 
 
-And now you now how long Americans need to travel to work, on average, with 95% confidence.
+And now you know a range of values you would expect for the true commute time for *all* Americans to take on. Furthermore, if you constructed these intervals for multiple different samples, you would expect that, on average, with 95% of them would capture this true commute time.
 
 
 ### Average number of hours worked
 
-Full-time employment is employment in which a person works a minimum number of hours defined as such by his/her employer. Companies in the United States commonly require 40 hours per week to be considered a full time employee. We will use data from the American Community Survey to estimate the number of hours Americans work.
+Full-time employment is employment in which a person works a minimum number of hours defined as such by his/her employer. Companies in the United States commonly require 40 hours per week to be considered a full time employee. This time, we will use data from the American Community Survey to estimate the number of hours Americans work, and see if it differs from our original estimate. 
 
 Use the `acs12_emp` dataset you created earlier; it's already loaded for you.
 
-### Instructions
+In this exercise, 
 
-- Create a 95% confidence interval using the `hrs_work` column.
-- *Interpret the confidence interval. Is it likely the average number of hours Americans work is equal to 40?*
+- Create a 95% confidence interval for `hrs_work`.
+- *Interpret the confidence interval. Is it likely the average number of hours Americans work is equal to 40?* 
+- *Compare the interval to the one obtained in the `gss` data. Do both intervals paint the same picture?*
+
+```{r Average_number_of_hours_worked-setup, include = FALSE}
+acs12_emp <- acs12 %>%
+  filter(employment == "employed")
+```
+
 
 ```{r Average_number_of_hours_worked, exercise=TRUE}
 # Run a t-test on hrs_work and look at the CI
-___
+acs12_emp %>% 
+  t_test(response = ___, 
+         conf_int = ___, 
+         conf_level = ___)
 ```
 
 <div id="Average_number_of_hours_worked-hint">
-**Hint:** Call `t.test()`, passing the `hrs_work` column of `acs12_emp`.
+**Hint:**   
+
+- Use `hrs_work` as the `response`.
+- Say you want a confidence interval by specifying `TRUE` for `conf_int`. 
+- Find a 95% confidence interval by setting `conf_level` to 0.95.
 </div>
 
 ```{r Average_number_of_hours_worked-solution}
 # Run a t-test on hrs_work and look at the CI
-t.test(acs12_emp$hrs_work)
+acs12_emp %>% 
+  t_test(response = hrs_work, 
+         conf_int = TRUE, 
+         conf_level = 0.95)
 ```
 
 ### 
@@ -346,35 +370,34 @@ For this analysis, it would have made more sense to use a subset excluding part 
 
 ## t-interval for paired data
 
-Next we discuss how we estimate the mean difference between data coming from two dependent groups, in other words, paired data. First, the good news: there's not much new here. We'll quickly see that we can summarize paired data in a way that allows us to re-use techniques we've already learned.
+Next we discuss how we estimate the mean difference between data coming from two dependent groups, in other words, paired data. First, the good news: there's not much new here. We'll quickly see that we can summarize paired data in a way that allows us to re-use techniques we've already learned!
 
 ### High School and Beyond
 
-> 200 observations were randomly sampled from the High School and Beyond survey.The same students took a reading and writing test. At a first glance, how are the distributions of reading and writing scores similar? How are they different?
+As usual, let's frame our discussion around a real-world problem. 200 observations were randomly sampled from the High School and Beyond survey.
 
-![](images/chp2-vid2-hsb2.png)
+> The same students took a reading and writing test. 
+> At a first glance, how are the distributions of reading and writing scores similar? How are they different?
 
-As usual, let's frame our discussion around a real-world problem. 200 observations were randomly sampled from the High School and Beyond survey. The same students took a reading and writing tests. At a first glance, how are the distributions of reading and writing scores similar and how are they different?
+```{r, echo = FALSE, out.width="50%"}
+knitr::include_graphics("images/chp2-vid2-hsb2.png")
+```
 
 It appears that the median writing score is slightly higher than the median reading score. Both distributions seem fairly symmetric. But the reading scores are slightly more right skewed, as evidenced by the median that is closer to the 25th percentile than the 75th percentile. Also, the reading scores are slightly more variable than the writing scores. That all being said, at a first glance it's difficult to tell if there's a difference in the reading and writing scores.
 
 
-
 ### Independent scores?
-
 
 > Can reading and writing scores for a given student student assumed to be independent of each other?
 > Probably not! 
 
-Can reading and writing scores for a given student student assumed to be independent of each other?
-
-A student's reading score is likely not independent of their writing score. If they are generally a high achieving student, they're likely to score highly on both tests.
+A student's reading score is likely not independent of their writing score. As both tests reflect students' knowledge, it is likely that they share information. 
 
 
 ### Analyzing paired data
 
 
-> - When two sets of observations have this special correspondence (not independent), they are said to be paired.
+> - When two sets of observations have this special correspondence (repeated observations), they are said to be paired.
 > - To analyze paired data, it is often useful to look at the difference in outcomes of each pair of observations:
 `diff = read − write`.
 
@@ -387,22 +410,23 @@ A student's reading score is likely not independent of their writing score. If t
 |     200|   63|    65|   -2|
 
 
-When two sets of observations have the special correspondence, or in other words, they're not independent, they're said to be paired. 
-
-To analyze paired data, it is often useful to look at the difference in outcomes of each pair of observations. So here for example, for each student, we subtract their writing score from their reading score, and create a new variable, called diff, for the difference between the two scores for each student.
-
-
+To analyze paired data, it is often useful to look at the difference in outcomes of each pair of observations. Here, for example, for each student we would subtract their writing score from their reading score to create a new variable, called `diff`, the difference between the two scores.
 
 ### Estimating the mean difference in paired data
 
 > Construct a 95% confidence interval for the mean difference between the average reading and writing scores.
 
-Our goal is to construct a 95% confidence interval for the mean difference between the average reading and writing scores.
+Our goal is to construct a 95% confidence interval for the true mean difference between the average reading and writing scores. 
 
-Implementation-wise there is not much new here. Our data is in a singe column, diff, so we simply build an interval for the mean of this single variable using the t-dot-test function.
+Notice here we are talking about the "mean difference" rather than the "difference in means." That is not an accident, it is how we talk about the mean of paired data. Here, we are interested in the mean of the differences between reading and writing scores. This is different than taking a difference in the mean of the writing scores and the mean of the reading scores. 
+
+Implementation-wise there is not much new here. Our data is in a singe column, `diff`, so we simply build an interval for the mean of this single variable using the `t_test()` function.
 
 ```{r echo=TRUE}
-t.test(hsb2$diff, conf.level = 0.95)
+hsb2 %>% 
+  t_test(response = diff,
+         conf_int = TRUE, 
+         conf_level = 0.95)
 ```
 
 The 95% confidence interval is found to be (-1.78, 0.69).
@@ -410,30 +434,29 @@ The 95% confidence interval is found to be (-1.78, 0.69).
 
 ### Interpreting the CI for mean difference in paired data
 
-> 95% CI for the mean difference in reading and writing scores (read - write) is (-1.78, 0.69) 
-> vs. 
-> We are 95% confident that the average reading score is  1.78 points lower to 0.69 points higher than the average writing score. 
-
-
 So how we interpret this 95% confidence interval for the mean difference between the reading and writing scores? 
 
 A standard interpretation would say something along the lines of "95% confidence interval for the mean difference in reading and writing scores (read minus write) is -1.78 to 0.69.
 
 But a good interpretation should convey directionality, in other words tell us which group is bigger than the other. 
 
-In this case we are 95% confident that the average reading score is  1.78 points lower to 0.69 points higher than the average writing score.
+> We are 95% confident that the true average reading score is between 1.78 points lower to 0.69 points higher than the average writing score. 
 
 Time to put this into practice.
 
 ### t-interval at various levels
 
-A random sample was taken of nearly 10% of UCLA courses. The most expensive textbook for each course was identified, and its price at the UCLA Bookstore and on Amazon.com were recorded. These data are recorded in the `textbooks` dataset. We want to test whether there is a difference between the average prices of textbooks sold in the bookstore vs. on Amazon. 
+A random sample was taken of nearly 10% of UCLA courses. The most expensive textbook for each course was identified, and its price at the UCLA Bookstore and on Amazon.com were recorded. These data are recorded in the `textbooks` dataset. We want to test whether there is a difference between the average prices of textbooks sold in the UCLA bookstore vs. on Amazon. 
 
-Since the book price data are *paired* (the price of the same book at the two stores are not independent), rather than using individual variables for the prices from each store, you will look at the a single variables of the differences in price. The `diff` column the UCLA Bookstore price minus the Amazon.com price for each book.
+Since the book price data are *paired* (the price of the same book at the two stores are not independent), rather than using individual variables for the prices from each store, you will look at the a single variables of the differences in price. The `diff` column can be calculated as the UCLA Bookstore price minus the Amazon.com price for each book.
+
+The data on these prices is stored in the `textbooks` dataset. The difference in prices has been calculated for you and stored in the `diff` column. 
+
+In this exercise you will: 
 
 - Construct a 90% confidence interval for the average difference in prices of the same textbook at at the UCLA bookstore and on Amazon.
-- Now construct the same interval at the 95% confidence level.
-- And now at the 99% confidence level.
+- Construct the same interval at the 95% confidence level.
+- And again at the 99% confidence level.
 - Take a note of the widths of the intervals. You'll need these for the next exercise.
 
 ```{r t-interval_at_various_levels-setup, include=FALSE}
@@ -445,28 +468,50 @@ textbooks <- textbooks %>%
 
 ```{r t-interval_at_various_levels, exercise=TRUE}
 # Run a t-test on diff with a 90% CI
-___(___, conf.level = ___)
+textbooks %>% 
+  t_test(response = ___,
+         conf_int = TRUE,
+         conf_level = ___)
 
 # Same with 95% CI
-___
+textbooks %>% 
+  t_test(response = ___,
+         conf_int = ___,
+         conf_level = ___)
 
 # Same with 99% CI
-___
+textbooks %>% 
+  t_test(response = ___,
+         conf_int = ___,
+         conf_level = ___)
 ```
 
-<div id="interval_at_various_levels-hint">
-**Hint:** Call `t.test()` three times, passing the `diff` column of `textbooks` and setting the `conf.level` each time.
+<div id="t-interval_at_various_levels-hint">
+**Hint:**  
+
+- Use the `diff` column as the `response`. 
+- Turn the confidence interval on by setting `conf_int` to `TRUE`.  
+- Change the `conf_level` to the specified with (either 0.90, 0.95, or 0.99).
 </div>
 
 ```{r t-interval_at_various_levels-solution}
 # Run a t-test on diff with a 90% CI
-t.test(textbooks$diff, conf.level = 0.90)
+textbooks %>% 
+  t_test(response = diff,
+         conf_int = TRUE,
+         conf.level = 0.90)
 
 # Same with 95% CI
-t.test(textbooks$diff, conf.level = 0.95)
+textbooks %>% 
+  t_test(response = diff,
+         conf_int = TRUE,
+         conf.level = 0.95)
 
 # Same with 99% CI
-t.test(textbooks$diff, conf.level = 0.99)
+textbooks %>% 
+  t_test(response = diff,
+         conf_int = TRUE,
+         conf.level = 0.99)
 ```
 
 ### 
@@ -480,135 +525,121 @@ Don't forget to take a mental note of the width of the intervals, as you'll need
 question("Which of the following is false about confidence intervals when all else is held constant?",
   correct = "Correct! A larger sample size will decrease the margin of error of the interval.",
   allow_retry = TRUE,
-  answer("As the confidence level increases, the margin of error of the interval increases as well.", message = "No, this is true. At a higher confidence level, the margin of error of the interval will be greater too."),
-  answer("As the confidence level increases, the width of the interval increases as well.", message = "No, this is true. A higher confidence level implies a wider confidence interval."),
-  answer("As the sample size increases, the margin of error of the interval increases as well.", correct = TRUE),
-  answer("As the sample size increases, the precision of the interval increases as well.", message = "No, this is true. A larger sample size will increase the precision of the interval.")
+  answer("As the confidence level increases, the margin of error of the interval increases as well.", 
+         message = "No, this is true. At a higher confidence level, the margin of error of the interval will be greater too."),
+  answer("As the confidence level increases, the width of the interval increases as well.", 
+         message = "No, this is true. A higher confidence level implies a wider confidence interval."),
+  answer("As the sample size increases, the margin of error of the interval increases as well.", 
+         correct = TRUE),
+  answer("As the sample size increases, the precision of the interval increases as well.", 
+         message = "No, this is true. A larger sample size will increase the precision of the interval.")
 )
 ```
 
 ## Testing for a mean with a t-test
 
-In the last lesson of this tutorial we discuss t-tests. The functionality in R will be familiar to you, it's the same t-dot-test function we've used previously and pretty much the same conditions for inference. The structure of a hypothesis test will also be familiar from the previous lesson where we did simulation based hypothesis tests. The only difference is that we use the t-distribution to approximate the sampling distribution of the sample mean and find the p-value as the tail area under the t-distribution curve.
+In the last lesson of this tutorial we discuss t-tests. The functionality in `R` will be familiar to you, it's the same `t_test()` function we've used previously and pretty much the same conditions for inference. The structure of a hypothesis test will also be familiar from the previous lesson where we did simulation based hypothesis tests. The only difference is that we use the t-distribution to approximate the sampling distribution of the sample mean and find the p-value as the tail area under the t-distribution curve.
 
 
 ### Hypotheses
 
 Let's revisit the High School and Beyond survey data. 
 
-> Do the data provide convincing evidence of a difference between the average reading and writing scores of students? Use a 5% significance level.
-> $H\_0: \mu\_{diff} = 0$, There is no difference between the average reading and writing scores.
-> $H\_A: \mu\_{diff} \ne 0$, There is a difference between the average reading and writing scores.
+> Do the data provide convincing evidence of a difference between the average reading and writing scores of students? Use a 5% significance level.  
+>
+> $H_0: \mu_{\text{diff}} = 0$, There is no difference between the average reading and writing scores. 
+>
+> $H_A: \mu_{\text{diff}} \ne 0$, There is a difference between the average reading and writing scores.
 
 Using the same High School and Beyond survey data from earlier, we answer the question "Do the data provide convincing evidence of a difference between the average reading and writing scores of students?" with a hypothesis test, at the 5% significance level.
 
-The null hypothesis, representing the status quo of "there is nothing going on", says the difference between the average reading and writing scores of all students in the population is 0. In other words mu diff is 0.
+The null hypothesis, representing the status quo of "there is nothing going on", says the average difference between the reading and writing scores of all students in the population is 0. In other words $\mu_{\text{diff}}$ is 0.
 
-and the alternative hypothesis, which follows from the research question, says that there is a difference. In other words mu diff is different than 0.
+The alternative hypothesis, which follows from the research question, says that there is a difference. In other words $\mu_{\text{diff}}$ is different than 0.
 
 
 ### Testing for a mean with a t-test
 
 ```{r, eval=FALSE, echo=TRUE}
-t.test(hsb2$diff, null = 0, alternative = "two.sided")
+hsb2 %>% 
+  t_test(response = diff,
+         null = 0, 
+         alternative = "two-sided", 
+         conf_int = FALSE)
 ```
 
-We use the t-dot-test function again. The first argument is the variable of interest: the paired differences between reading and writing scores. We also specify a null value, which is 0, and an alternative hypothesis, which is two sided.
+We use the `t_test()` function again. The first argument is the variable of interest: the paired differences between reading and writing scores (`diff`). We then specify a `null` value for the hypothesis test, which is 0. We specify what direction should be used to calculate the p-value, based on the alternative hypothesis. Finally, since we are carrying out a hypothesis test, we can turn the confidence interval off (by setting it to `FALSE`). 
 
 
 ### Testing for a mean with a t-test
 
+The resulting output states a p-value of 0.387.  With such a large p-value we fail to reject the null hypothesis and conclude that the data do not provide convincing evidence of a mean difference between the average reading and writing scores of students.
 
-```{r , eval=FALSE, echo=TRUE}
-t.test(hsb2$diff, null = 0, alternative = "two.sided")
-```
-```
-	One Sample t-test
-
-data:  hsb2$diff
-t = -0.86731, df = 199, p-value = 0.3868
-alternative hypothesis: true mean is not equal to 0
-95 percent confidence interval:
- -1.7841424  0.6941424
-sample estimates:
-mean of x 
-   -0.545 
-```
-
-The resulting output states a p-value of 0.3868.  With such a large p-value we fail to reject the null hypothesis and conclude that the data do not provide convincing evidence of a difference between the average reading and writing scores of students.
-
-Now let's try some examples.
+Now let's try some more examples.
 
 ### Estimate the median difference in textbook prices
 
-Suppose instead of the mean, we want to estimate the median difference in prices of the same textbook at the UCLA bookstore and on Amazon. You can't do this using a t-test, as the Central Limit Theorem only talks about means, not medians. You'll use an **infer** pipeline to estimate the median.
+Suppose instead of the mean, we want to estimate the median difference in prices of the same textbook at the UCLA bookstore and on Amazon. You can't do this using a t-test, as the Central Limit Theorem only talks about means, not medians. You'll use an **infer** pipeline to estimate the difference in medians.
 
 ### 
 
-First, for the price differences, generate 500 bootstrap replicates and calculate their medians.
+First, for the price differences, generate 1000 bootstrap replicates and calculate their medians. Remember, for the test of a single mean you only need to `specify()` a `response` variable. 
 
 ```{r estimate_the_median_difference_in_textbook_prices, exercise=TRUE}
 # Calculate 500 bootstrap medians of diff
-textdiff_med_ci <- ___ %>%
-  ___ %>%
-  ___ %>%
-  ___
+textdiff_med_ci <- textbooks %>%
+  sepecify(response = ___) %>%
+  generate(reps = ___, type = ___) %>%
+  calculate(stat = ___)
 ```
 
 <div id="estimate_the_median_difference_in_textbook_prices-hint">
-**Hint:** 
-- Call `specify()`, setting `response` to `diff`.
-- Call `generate()`, setting `reps` to `500` and `type` to `"bootstrap"`.
-- Call `calculate()`, setting `stat` to `"median"`.
+**Hint:**  
+
+- Use `specify()`, setting `response` to `diff`.
+- Use `generate()`, setting `reps` to `1000` and `type` to `"bootstrap"`.
+- Use `calculate()`, setting `stat` to `"median"`.
 </div>
 
 ```{r estimate_the_median_difference_in_textbook_prices-solution}
 # Calculate 500 bootstrap medians of diff
 textdiff_med_ci <- textbooks %>%
   specify(response = diff) %>%
-  generate(reps = 500, type = "bootstrap") %>%
+  generate(reps = 1000, type = "bootstrap") %>%
   calculate(stat = "median")
 ```
 
 ###
 
-Then, calculate a 95% confidence interval for the bootstrap median price differences using the percentile method.
+Then, calculate a 95% confidence interval for the bootstrap median price differences using the `get_confidence_interval()` function. Specifically, use the `"percentile"` method.
+
+```{r estimate_the_median_difference_in_textbook_prices_2-setup, include = FALSE}
+# From previous step
+textdiff_med_ci <- textbooks %>%
+  specify(response = diff) %>%
+  generate(reps = 500, type = "bootstrap") %>%
+  calculate(stat = "median")
+
+```
 
 
 ```{r estimate_the_median_difference_in_textbook_prices_2, exercise=TRUE}
-# From previous step
-textdiff_med_ci <- textbooks %>%
-  specify(response = diff) %>%
-  generate(reps = 500, type = "bootstrap") %>%
-  calculate(stat = "median")
-
 # Calculate the 95% CI via percentile method
-textdiff_med_ci %>%
-  ___(
-    l = ___,
-    u = ___
-  )
+textdiff_med_ci %>% 
+  get_confidence_interval(level = ___, 
+                          type = ___)
 ```
 
 <div id="estimate_the_median_difference_in_textbook_prices_2-hint">
-**Hint:** 
-- Call `summarize()`, setting `l` to the `0.025` quantile of `stat`.
-- The `probs` arguments for the `l` and `u` quantiles should add up to one.
+**Hint:** Set `level` equal to 0.95 and `type` equal to `"percentile"`. 
 </div>
 
 ```{r estimate_the_median_difference_in_textbook_prices_2-solution}
-# From previous step
-textdiff_med_ci <- textbooks %>%
-  specify(response = diff) %>%
-  generate(reps = 500, type = "bootstrap") %>%
-  calculate(stat = "median")
-
 # Calculate the 95% CI via percentile method
-textdiff_med_ci %>%
-  summarize(
-    l = quantile(stat, 0.025),
-    u = quantile(stat, 0.975)
-  )
+textdiff_med_ci %>% 
+  get_confidence_interval(level = 0.95, 
+                          type = "percentile")
+ 
 ```
 
 ### 
@@ -627,11 +658,11 @@ First, add a column to `hsb2` named `diff` containing the `math` scores minus th
 ```{r test-for-a-difference-in-median-test-scores, exercise=TRUE}
 # Add a column, diff, of math minus science
 hsb2 <- hsb2 %>%
-  ___
+  mutate(diff = ___)
 ```
 
 <div id="test-for-a-difference-in-median-test-scores-hint">
-**Hint:** Call `mutate()`, setting `diff` to `math` minus `science`.
+**Hint:** Calculate `diff` as `math` minus `science`.
 </div>
 
 ```{r test-for-a-difference-in-median-test-scores-solution}
@@ -646,154 +677,122 @@ Then,
 
 - Specify `diff` as the response.
 - Use a point null hypothesis of the score difference being `med = 0`.
-- Generate 500 bootstrap replicates.
-- Calculate the median.
+- Generate 1000 shifted bootstrap samples.
+- Calculate the median for each bootstrap sample.
 
-
-```{r test-for-a-difference-in-median-test-scores_2, exercise=TRUE}
+```{r test-for-a-difference-in-median-test-scores_2-setup, include = FALSE}
 # From previous step
 hsb2 <- hsb2 %>%
   mutate(diff = math - science)
- 
-n_replicates <- 500
 
-# Generate 500 bootstrap medians centered at null
+```
+
+
+```{r test-for-a-difference-in-median-test-scores_2, exercise=TRUE}
+# Generate 1000 bootstrap medians centered at null
 scorediff_med_ht <- hsb2 %>%
-  ___ %>%
-  ___ %>% 
-  ___ %>% 
-  ___
+  specify(response = ___) %>%
+  hypothesize(null = "point", med = ___) %>% 
+  generate(reps = ___, type = "bootstrap") %>% 
+  calculate(stat = ___)
 ```
 
 <div id="test-for-a-difference-in-median-test-scores_2-hint">
 **Hint:** 
-- Call `specify()`, setting `response` to `diff`.
-- Call `hypothesize()`, setting `null` to `"point"` and `mu` to `0`.
-- Call `generate()`, setting `reps` to `n_replicates` and `type` to `"bootstrap"`.
-- Call `calculate()`, setting `stat` to `"median"`.
+- Use `specify()`, setting `response` to `diff`.
+- Use `hypothesize()`, setting `null` to `"point"` and `mu` to `0`.
+- Use `generate()`, setting `reps` to 1000 and `type` to `"bootstrap"`.
+- Use `calculate()`, setting `stat` to `"median"`.
 </div>
 
 ```{r test-for-a-difference-in-median-test-scores_2-solution}
-# From previous step
-hsb2 <- hsb2 %>%
-  mutate(diff = math - science)
- 
-n_replicates <- 500
-
-# Generate 500 bootstrap medians centered at null
 scorediff_med_ht <- hsb2 %>%
   specify(response = diff) %>%
   hypothesize(null = "point", med = 0) %>% 
-  generate(reps = n_replicates, type = "bootstrap") %>% 
+  generate(reps = 1000, type = "bootstrap") %>% 
   calculate(stat = "median")
 ```
 
 ### 
 
-Then, calculate the median observed score difference and pull out the value.
+Next, find the observed median difference (`diff`) using the `summarize()` function.   
 
-
-```{r test-for-a-difference-in-median-test-scores_3, exercise=TRUE}
-# From previous steps
-n_replicates <- 500
+```{r test-for-a-difference-in-median-test-scores_3-setup, include = FALSE}
 hsb2 <- hsb2 %>%
   mutate(diff = math - science)
+
 scorediff_med_ht <- hsb2 %>%
   specify(response = diff) %>%
   hypothesize(null = "point", med = 0) %>% 
-  generate(reps = n_replicates, type = "bootstrap") %>% 
+  generate(reps = 1000, type = "bootstrap") %>% 
   calculate(stat = "median")
-  
+
+```
+
+
+```{r test-for-a-difference-in-median-test-scores_3, exercise=TRUE}
 # Calculate observed median of differences
 scorediff_med_obs <- hsb2 %>%
-  ___(median_diff = ___) %>%
-  ___
+  summarize(median_diff = ___) 
+
+## See what the value is 
+scorediff_med_obs
 ```
 
 
 <div id="test-for-a-difference-in-median-test-scores_3-hint">
 **Hint:** 
-- Call `summarize()`, setting `median_diff` to the median of `diff`.
-- Call `pull()` without arguments.
+
+- Set `median_diff` to the median of the observed `diff` column.
 </div>
 
 ```{r test-for-a-difference-in-median-test-scores_3-solution}
-# From previous steps
-n_replicates <- 500
-hsb2 <- hsb2 %>%
-  mutate(diff = math - science)
-scorediff_med_ht <- hsb2 %>%
-  specify(response = diff) %>%
-  hypothesize(null = "point", med = 0) %>% 
-  generate(reps = n_replicates, type = "bootstrap") %>% 
-  calculate(stat = "median")
-  
 # Calculate observed median of differences
 scorediff_med_obs <- hsb2 %>%
-  summarize(median_diff = median(diff)) %>%
-  pull()
+  summarize(median_diff = median(diff))
+
+## See what the value is 
+scorediff_med_obs
 ```
 
 ### 
 
-And finally, calculate the two-sided p-value.
+And finally, calculate the two-sided p-value using the `get_p_value()` function. Remember, you need to specify what the observed median difference is (`scorediff_med_obs`) and the direction of the alternative hypothesis (`"two-sided"`). 
 
-- Filter for rows where the bootstrap median is greater than or equal to the observed median.
-- Summarize to calculate `one_sided_p_val` as the number of rows in the filtered dataset divided by the number of replicates.
-- Calculate `two_sided_p_val` from `one_sided_p_val`.
-
-
-```{r test-for-a-difference-in-median-test-scores_4, exercise=TRUE}
-# From previous steps
-n_replicates <- 500
+```{r test-for-a-difference-in-median-test-scores_4-setup, include = FALSE}
 hsb2 <- hsb2 %>%
   mutate(diff = math - science)
 scorediff_med_ht <- hsb2 %>%
   specify(response = diff) %>%
   hypothesize(null = "point", med = 0) %>% 
-  generate(reps = n_replicates, type = "bootstrap") %>% 
+  generate(reps = 1000, type = "bootstrap") %>% 
   calculate(stat = "median")
+
 scorediff_med_obs <- hsb2 %>%
   summarize(median_diff = median(diff)) %>%
   pull()
-  
+```
+
+
+```{r test-for-a-difference-in-median-test-scores_4, exercise=TRUE}
 # Calculate two-sided p-value
 scorediff_med_ht %>%
-  ___ %>%
-  ___(
-    one_sided_p_val = ___,
-    two_sided_p_val = ___
-  )
+  get_p_value(obs_stat = ___, 
+              direction = ___)
 ```
 
 <div id="test-for-a-difference-in-median-test-scores_4-hint">
 **Hint:** 
-- Call `filter()`, using the condition `stat` greater than or equal to the observed median score difference.
-- Call `summarize()`, setting `one_sided_p_val` to the number of rows, `n()`, divided by the total number of replicates, `n_replicates`.
-- Inside `summarize()`, set `two_sided_p_val` to double `one_sided_p_val`.
+
+- Use `scorediff_med_obs` as the observed statistic. 
+- Use `"two-sided"` as the direction in the alternative. 
 </div>
 
 ```{r test-for-a-difference-in-median-test-scores_4-solution}
-# From previous steps
-n_replicates <- 500
-hsb2 <- hsb2 %>%
-  mutate(diff = math - science)
-scorediff_med_ht <- hsb2 %>%
-  specify(response = diff) %>%
-  hypothesize(null = "point", med = 0) %>% 
-  generate(reps = n_replicates, type = "bootstrap") %>% 
-  calculate(stat = "median")
-scorediff_med_obs <- hsb2 %>%
-  summarize(median_diff = median(diff)) %>%
-  pull()
-  
 # Calculate two-sided p-value
 scorediff_med_ht %>%
-  filter(stat >= scorediff_med_obs) %>%
-  summarize(
-    one_sided_p_val = n() / n_replicates,
-    two_sided_p_val = 2 * one_sided_p_val
-  )
+  get_p_value(obs_stat = scorediff_med_obs, 
+              direction = "two-sided")
 ```
 
 ### 

--- a/07-inference-for-numerical-responses/03-lesson/07-03-lesson.Rmd
+++ b/07-inference-for-numerical-responses/03-lesson/07-03-lesson.Rmd
@@ -29,19 +29,10 @@ knitr::opts_chunk$set(fig.align = "center",
 
 set.seed(421398)
 
-# add ver variables to acs
-acs12 <- acs12 %>%
-  mutate(
-    hrly_pay = income / (52 * hrs_work),
-    citizen = case_when(
-      citizen == "no" ~ "Non-citizen", 
-      citizen == "yes" ~ "Citizen"
-      )  
-  )
-
 # Calculate difference between before and after
 stem_cell <- stem_cell %>%
   mutate(change = after - before)
+
 ```
 
 ## Hypothesis testing for comparing two means
@@ -87,37 +78,39 @@ These data were collected as part of a study in which sheep that have had a hear
 In order to do this we will first calculate the difference between before treatment and after treatment heart pumping capacities for each sheep. We call this variable "change". 
 We want to evaluate whether the data suggest that average change is higher, on average, for the treatment group.
 
+
+
 ### 
 
-> Step 2. Set the hypotheses:
-> $H\_0: \mu\_{esc} = \mu\_{ctrl}$; There is no difference between average change in treatment and control groups.
-> $H\_A: \mu\_{esc} > \mu\_{ctrl}$; There is a difference between average change in treatment and control groups. 
+> Step 2. Set the hypotheses:  
+> $H_0: \mu_{esc} = \mu_{ctrl}$; There is no difference between average change in heart pumping capacity between the treatment and control groups.  
+> $H_A: \mu_{esc} > \mu_{ctrl}$; The sheep receiving the embryonic stem cell therapy have a larger change in heart pumping capacity compared to the sheep receiving the control. 
 
 Then, we set our hypotheses.
 
-Our null hypothesis should state the status quo, in other words, "there is nothing going on". In context, this means no difference between the average changes in the treatment and control groups.
+Our null hypothesis should state the status quo, in other words, "there is nothing going on". In context, this means no difference between the average change in the sheeps' heart pumping capacity between the treatment and control groups.
 
-The alternative hypothesis says that the average change is higher for those in the treatment group compared to the control.
+The alternative hypothesis says that the average change in the heart pumping capacity is higher for the sheep in the (esc) treatment group versus the sheep in the control group.
 
 ### 
 
-> Step 3. Conduct the hypothesis test.
-> - Write the values of `change` on 18 index cards. 
-> - (1) Shuffle the cards and randomly split them into two equal sized decks: treatment and control. 
-> - (2) Calculate and record the test statistic: difference in average `change` between treatment and control. 
-> - Repeat (1) and (2) many times to generate the sampling distribution. 
-> - Calculate p-value as the percentage of simulations where the test statistic is at least as extreme as the observed difference in sample means. 
+> Step 3. Conduct the hypothesis test.  
+> - Write the values of `change` on 18 index cards.   
+> - (1) Shuffle the cards and randomly split them into two equal sized decks: treatment and control.   
+> - (2) Calculate and record the test statistic: difference in average `change` between treatment and control.   
+> - Repeat (1) and (2) many times to generate the sampling distribution of the difference in means under the null hypothesis.    
+> - Calculate p-value as the percentage of simulations where the test statistic is at least as extreme as the observed difference in sample means.   
 
 
 Finally, we conduct the hypothesis test.
 
 Conceptually here is how we go about it.
 
-First, we write the values of "change" on 18 index cards.
+First, we write the values of "change" on 18 index cards, one card for each sheep.
 
-Then we shuffle these cards and randomly split them into two equal sized decks, one representing treatment and other representing control.
+Then we shuffle these cards and randomly split them into two equal sized decks, one representing treatment and other representing control. Note: the decks are equally sized because there were the same number of sheep in the treatment and control groups. 
 
-We then calculate and record the test statistic: difference in average change between treatment and control. At this point we have no control over which card ended up in which pile. Since the cards are randomly shuffled into the two decks, we would not expect to see a difference between the average change values in each deck. In other words, we would expect the simulated difference between the two sample means to be 0. But of course, this number will not be exactly 0. Just by random chance it can be just a bit different than 0, or quite different than 0.
+We then calculate and record the test statistic: difference in average change between the treatment and control groups. At this point we have no control over which card ended up in which pile. Since the cards are randomly shuffled into the two decks, we would not expect to see a difference in the average change values betweent the two decks. In other words, we would expect the simulated difference between the two sample means to be around 0. But of course, this number will not be exactly 0. Just by random chance it can be just a bit different than 0, or quite different than 0. That's what we need simulation to figure out! 
 
 We repeat the simulation many times in order to get a sense of how much the simulated difference in means varies.
 
@@ -142,12 +135,11 @@ Instead, we use computation to conduct this simulation, specifically using the i
 
 ```{r eval=FALSE, echo=TRUE}
 diff_ht_mean <- stem_cell %>%
-  specify(__) %>%                    # y ~ x
+  specify(__) %>%   # Use the form: y-variable ~ x-variable
   ...
 ```
 
-
-We start with the data frame containing our variables of interest, and specify our model as response vs. explanatory. In our example the response variable is change and the explanatory variable is treatment group.
+We start with the data frame containing our variables of interest, and specify our model as response vs. explanatory. In our example the response variable is `change` and the explanatory variable is treatment (`trmt`) group.
 
 ### Hypothesis test: hypothesize
 
@@ -155,12 +147,12 @@ We start with the data frame containing our variables of interest, and specify o
 
 ```{r eval=FALSE, echo=TRUE}
 diff_ht_mean <- stem_cell %>%
-  specify(__) %>%                    # y ~ x
-  hypothesize(null = __) %>%         # "independence" or "point"
-  ...
+  specify(__) %>%                    # Use the form: y-variable ~ x-variable
+  hypothesize(null = __) %>%         # Use a hypothesis of "independence" 
+  
 ```
 
-We then declare the null hypothesis. The null argument in the hypothesize function can be set to a point value or to independence, indicating that the response and explanatory variables are independent of each other.
+We then declare the null hypothesis. For a difference in means, the null hypothesize should be specified as `"independence"`, which indicates that we are assuming the change in heart pumping capacity is independent of the treatment group the sheep was in. 
 
 ### Hypothesis test: generate resamples
 
@@ -168,13 +160,13 @@ We then declare the null hypothesis. The null argument in the hypothesize functi
 
 ```{r eval=FALSE, echo=TRUE}
 diff_ht_mean <- stem_cell %>%
-  specify(__) %>%                    # y ~ x
-  hypothesize(null = __) %>%         # "independence" or "point"
-  generate(reps = __, type = __) %>% # "bootstrap", "permute", or "simulate"
+  specify(__) %>%                    # Use the form: y-variable ~ x-variable
+  hypothesize(null = __) %>%         # Use a hypothesis of "independence"
+  generate(reps = __, type = __) %>% # Generate permutation ("permute") statistics and specify how many (at least 1000)
   ...
 ```
 
-Then, using the data, the model we specified, and the null hypothesis we declared, we generate many resamples by permuting the labels of the two groups.
+Then, using the data, the model we specified, and the null hypothesis we declared, we generate many new samples by permuting the labels of the two groups.
 
 ### Hypothesis test: calculate the test statistic
 
@@ -182,35 +174,36 @@ Then, using the data, the model we specified, and the null hypothesis we declare
 
 ```{r eval=FALSE, echo=TRUE}
 diff_ht_mean <- stem_cell %>%
-  specify(__) %>%                    # y ~ x
-  hypothesize(null = __) %>%         # "independence" or "point"
-  generate(reps = _N_, type = __) %>%# "bootstrap", "permute", or "simulate"
-  calculate(stat = "diff in means")  # type of statistic to calculate
+  specify(__) %>%                     # Use the form: y-variable ~ x-variable
+  hypothesize(null = __) %>%          # Use a hypothesis of "independence" 
+  generate(reps = _N_, type = __) %>% # Generate permutation ("permute") statistics and specify how many (at least 1000)
+  calculate(stat = "diff in means", order = c("trmt", "ctrl")   # Specify to calculate a difference in means and what order of subtraction to use
 ```
 
+Finally, we calculate the test statistic for each of our permutations. The statistic we're interested in is the difference in means and we want to use $\mu_{esc} - \mu_{ctrl}$ as our order of subtraction. 
 
-Finally, we calculate the test statistic for each of our resamples. The statistic we're interested in is the difference in means.
+Since we're testing for a difference, the order in which we subtract matters. We can specify it using the `order` argument in the `calculate()` function. For example, to achieve `group1 - group2` use `order = c("group1", "group2")`.
 
 
 ### Hypothesis test: calculate the p-value
 
 
-> Calculate the p-value as the proportion of simulations where the simulated difference between the sample means is at least as extreme as the observed
-> $$P ((\bar{x}\_{esc,sim} - \bar{x}\_{ctrl,sim}) \ge (\bar{x}\_{esc,obs} - \bar{x}\_{ctrl,obs}))$$
+> Calculate the p-value as the proportion of simulations where the simulated difference between the sample means is at least as extreme as the observed  
+> $$ \frac{ \text{number of permutations} \ge (\bar{x}_{esc, obs} - \bar{x}_{ctrl, obs})}{ \text{number of reps generated}} $$
 
 
 Using the simulated sample statistics, we calculate the p-value as the proportion of simulations where the simulated difference between the sample means is at least as extreme as the one observed.
 
 
-Now it's your turn.
+We've walked you through the steps, now it's your turn!
 
 ### Evaluating the effectiveness of stem cell treatment
 
-Now that we set out hypotheses, we can calculate the observed difference in means between the treatment and control groups. The `stem_cell` data frame gives us the pumping capacity of the heart before and after the experiment. So first we need to find the difference between these for each experimental unit, and then use these `change` values to calculate the observed difference in mean change between treatment and control groups.
+The `stem_cell` data frame gives us the pumping capacity of the heart before and after the experiment. So first we need to find the difference between these for each experimental unit, and then use these `change` values to calculate the observed difference in mean change between the treatment and control groups.
 
 ###
 
-First, add a column to `stem_cell` named `change`, equal to `after` minus `before`.
+First, add a column to `stem_cell` named `change`, equal to the difference between the `after` and `before` columns.
 
 ```{r stem_cell, exercise=TRUE}
 # Calculate difference between before and after
@@ -230,59 +223,34 @@ stem_cell <- stem_cell %>%
 
 ### 
 
-Then, calculate observed difference in means between treatment groups.
+Then, calculate observed difference in means between treatment groups, using the infer package. 
+Here, since we aren't hypothesizing or permuting we only need to functions, `specify()` and `calculate()`. 
 
-- Group by the treatment group, `trmt`.
-- Summarize to calculate the mean change.
-- Pull out the calculated value.
-- Calculate the `diff()`erence between the two numbers.
+First, use the `specify()` function to specify the explanatory (`trmt`) and response (`change`) variables. 
 
+Then, use the `calculate()` function to calculate the observed difference in means, being sure to use $\bar{x}_{esc} - \bar{x}_{ctrl}$. 
 
-```{r steam_cell_2, exercise=TRUE}
+```{r stem_cell_2, exercise=TRUE}
 # From previous step
 stem_cell <- stem_cell %>%
   mutate(change = after - before)
   
 # Calculate observed difference in means
 diff_mean <- stem_cell %>%
-  # Group by treatment group
-  ___ %>%
-  # Calculate mean change for each group
-  ___(mean_change = ___) %>% 
-  # Pull out the value
-  ___ %>%
-  # Calculate difference
-  ___
-  
+  # Specify the response and explanatory variables
+  specify(___) %>%
+  # Calculate observed difference in means 
+  calculate(___)
+
 # See the result
 diff_mean
 ```
 
 <div id="stem_cell_2-hint">
-**Hint:**
-- Call `group_by()`, passing `trmt`.
-- Call `summarize()`, setting `mean_change` to the mean of `change`.
+**Hint:**   
+- Use `change ~ trmt` to specify the response and explanatory variables.   
+- Use `"diff in means"` to calculate the difference in means for each group, and `order = c("esc", "ctrl")` to get the correct order of subtraction. 
 </div>
-
-```{r steam_cell_2-solution}
-# From previous step
-stem_cell <- stem_cell %>%
-  mutate(change = after - before)
-  
-# Calculate observed difference in means
-diff_mean <- stem_cell %>%
-  # Group by treatment group
-  group_by(trmt) %>%
-  # Calculate mean change for each group
-  summarize(mean_change = mean(change)) %>% 
-  # Pull out the value
-  pull() %>%
-  # Calculate difference
-  diff()
-  
-# See the result
-diff_mean
-```
 
 ### 
 
@@ -292,30 +260,26 @@ Well done! We will use this observed difference in the following exercises.
 
 Conduct the hypothesis test and compute the p-value for evaluating whether there is a difference between the mean heart pumping capacities of sheep's hearts in the control and treatment groups.
 
-Since we're testing for a difference, the order in which we subtract matters. We can specify it using the `order` argument in the `calculate()` function. For example, to achieve `group1 - group2` use `order = c("group1", "group2")`.
-
 ```{r stem_cell_3-setup, include=FALSE}
 # Calculate observed difference in means
 diff_mean <- stem_cell %>%
-  group_by(trmt) %>%                         
-  summarize(mean_change = mean(change)) %>%  
-  pull() %>%                                 
-  diff()
+  # Specify the response and explanatory variables
+  specify(change ~ trmt) %>%
+  # Calculate observed difference in means 
+  calculate(stat = "diff in means", order = c("esc", "ctrl"))
 ```
 
 ### 
 
-First, generate 1000 differences in means via randomization.
+First, generate 1000 differences in means via randomization (we can call it this because the treatment was randomly assigned).
 
-- Specify change versus treatment group.
-- Use an independence hypothesis.
-- Generate 1000 replicates via permutation.
-- Calculate the difference in means (`esc` first, then `ctrl`).
+- `specify()` the response and explanatory variables.
+- `hypothesize()` that the treatment and the response are `"independent"`. 
+- Generate 1000 `reps` via permutation (`"permute"`).
+- Calculate the permuted difference in means (`esc` first, then `ctrl`).
 
 
 ```{r stem_cell_3, exercise=TRUE}
-n_replicates <- 1000
-
 # Generate 1000 differences in means via randomization
 diff_mean_ht <- stem_cell %>%
   # y ~ x
@@ -325,7 +289,7 @@ diff_mean_ht <- stem_cell %>%
   # Shuffle labels 1000 times
   generate(reps = ___, type = "___") %>% 
   # Calculate test statistic
-  calculate(stat = "___", order = c("esc", "___") 
+  calculate(stat = "___", order = c("esc", "___")) 
 ```
 
 <div id="stem_cell_3-hint">
@@ -337,8 +301,6 @@ diff_mean_ht <- stem_cell %>%
 </div>
 
 ```{r stem_cell_3-solution}
-n_replicates <- 1000
-
 # Generate 1000 differences in means via randomization
 diff_mean_ht <- stem_cell %>%
   # y ~ x
@@ -353,54 +315,49 @@ diff_mean_ht <- stem_cell %>%
 
 ### 
 
-Then, calculate the one-sided p-value.
+Then, calculate the one-sided p-value. Use the `get_p_value()` function to survey how many of the permuted differences in means are as large or larger than the observed difference. 
 
-- Filter for replicates where the simulated test statistic is at least as extreme as the observed statistic.
-- Summarize to calculate the p-value as the number of rows in the filtered dataset divided by the number of replicates.
+- Use the previously calculated difference in means stored inside `diff_mean` as the observed statistic. 
+- Use a greater than alternative hypothesis to calculate the p-value. 
 
-
-```{r stem_cell_4, exercise=TRUE}
-# From previous step
-n_replicates <- 1000
-diff_mean_ht <- stem_cell %>%
-  specify(change ~ trmt) %>% 
-  hypothesize(null = "independence") %>%  
-  generate(reps = n_replicates, type = "permute") %>% 
+```{r stem_cell_4-setup, include=FALSE}
+# Calculate observed difference in means
+diff_mean <- stem_cell %>%
+  # Specify the response and explanatory variables
+  specify(change ~ trmt) %>%
+  # Calculate observed difference in means 
   calculate(stat = "diff in means", order = c("esc", "ctrl"))
-  
-diff_mean_ht %>%
-  # Filter for simulated test statistics at least as extreme as observed
-  filter(___) %>%
-  # Calculate p-value
-  summarize(p_val = ___)
+
+# Generate 1000 differences in means via randomization
+diff_mean_ht <- stem_cell %>%
+  # y ~ x
+  specify(change ~ trmt) %>% 
+  # Null = no difference between means
+  hypothesize(null = "independence") %>%  
+  # Shuffle labels 1000 times
+  generate(reps = 1000, type = "permute") %>% 
+  # Calculate test statistic
+  calculate(stat = "diff in means", order = c("esc", "ctrl")) 
+
 ```
 
-<div id="stem_cell_4-hint">
-**Hint:**
-- Call `filter()`, using the condition `stat` greater than or equal to the observed difference in means.
-- Call `summarize()`, setting `p_val` to the number of rows, `n()`, divided by the total number of replicates, `n_replicates`.
-</div>
+```{r stem_cell_4, exercise=TRUE}
+diff_mean_ht %>%
+  # use diff_mean as the observed statistic, and "greater" as the direction
+  get_p_value(___) 
+
+```
 
 ```{r stem_cell_4-solution}
-# From previous step
-n_replicates <- 1000
-diff_mean_ht <- stem_cell %>%
-  specify(change ~ trmt) %>% 
-  hypothesize(null = "independence") %>%  
-  generate(reps = n_replicates, type = "permute") %>% 
-  calculate(stat = "diff in means", order = c("esc", "ctrl"))
-  
 diff_mean_ht %>%
-  # Filter for simulated test statistics greater than observed
-  filter(stat >= diff_mean) %>%
-  # Calculate p-value
-  summarize(p_val = n() / n_replicates)
+  # use diff_mean as the observed statistic, and "greater" as the direction
+  get_p_value(obs_stat = diff_mean, direction = "greater") 
 ```
 
 ### Conclusion of the hypothesis test
 
 
-The p-value of the previous test was found to be 0.001. Suppose the significance level of the test is 1%. Fill in the blanks: 
+The p-value of the previous test was found to be 0.002. Suppose the significance level of the test is 1%. Fill in the blanks: 
 
 ```{r quiz_1}
 quiz(
@@ -426,7 +383,7 @@ First, filter `ncbirths` for rows where `habit` is non-missing.
 ```{r smoking, exercise=TRUE}
 # Filter for subjects with non-missing habit
 ncbirths_complete_habit <- ncbirths %>%
-  ___
+  filter(___)
 ```
 
 <div id="smoking-hint">
@@ -441,188 +398,146 @@ ncbirths_complete_habit <- ncbirths %>%
 
 ### 
 
-Then, calculate observed difference in means between smoking habit groups.
 
-- Group by the smoking habit group, `habit`.
-- Summarize to calculate the mean weight.
-- Pull out the calculated value.
-- Calculate the difference between the two numbers.
+Next, use `specify()` and `calculate()` to calculate observed difference in mean baby `weight` between smoking habit groups. Use $\bar{x}_{nonsmoker} - \bar{x}_{smoker}$. 
 
-
-```{r smoking_2, exercise=TRUE}
-# From previous step
+```{r smoking_2-setup, include = FALSE}
+# From previous steps
 ncbirths_complete_habit <- ncbirths %>%
   filter(!is.na(habit))
+```
+
+```{r smoking_2, exercise=TRUE}
 
 # Calculate observed difference in means
 diff_mean_obs <- ncbirths_complete_habit %>%
-  # Group by habit group
-  ___ %>%
-  # Calculate mean weight for each group
-  ___(mean_weight = ___) %>%
-  # Pull out the value
-  ___ %>%
-  # Calculate the difference
-  ___ 
+  # Specify the response and explanatory variables
+  specify(___) %>%
+  # Calculate the observed difference in means
+  calculate(stat = " ", order = c("nonsmoker", " "))
 ```
 
 <div id="smoking_2-hint">
-**Hint:** 
-- Call `group_by()`, passing `habit`.
-- Call `summarize()`, setting `mean_weight` to the mean of `weight`.
+**Hint:**   
+- Use `weight ~ habit` to specify the response and explanatory variables.   
+- Use `"diff in means"` to calculate the difference in means for each group, and `order = c("nonsmoker", "smoker")` to get the correct order of subtraction. 
 </div>
 
 ```{r smoking_2-solution}
-# From previous step
-ncbirths_complete_habit <- ncbirths %>%
-  filter(!is.na(habit))
 
 # Calculate observed difference in means
 diff_mean_obs <- ncbirths_complete_habit %>%
-  # Group by habit group
-  group_by(habit) %>%
-  # Calculate mean weight for each group
-  summarize(mean_weight = mean(weight)) %>%
-  # Pull out the value
-  pull() %>%
-  # Calculate the difference
-  diff() 
+  # Specify the response and explanatory variables
+  specify(weight ~ habit) %>%
+  # Calculate the observed difference in means
+  calculate(stat = "diff in means", order = c("nonsmoker", "smoker"))
 ```
 
 ### 
 
-Then, generate 1000 differences in means via randomization and store as `diff_mean_ht`
+Then, generate 1000 differences in means via permutation and store as `diff_mean_ht`
 
-- Specify the model as birth weight versus smoking habit.
-- Set the hypothesis that the variables are independent.
-- Generate 1000 samples via permutation.
-- Calculate the difference in means at each iteration. The order should have `"nonsmoker"`s first, then `"smoker"`s.
+- `specify()` the model as birth `weight` versus smoking `habit`.
+- `hypothesize()` that the variables are independent.
+- `generate()` 1000 samples via permutation.
+- `calculate()` the difference in means for each permutation. The order should have `"nonsmoker"`s first, then `"smoker"`s.
 
-
-```{r smoking_3, exercise=TRUE}
+```{r smoking_3-setup, include = FALSE}
 # From previous steps
 ncbirths_complete_habit <- ncbirths %>%
   filter(!is.na(habit))
+
 diff_mean_obs <- ncbirths_complete_habit %>%
   group_by(habit) %>%
   summarize(mean_weight = mean(weight)) %>%
   pull() %>%
   diff()
+```
 
-n_replicates <- 1000
 
+```{r smoking_3, exercise=TRUE}
 # Generate 1000 differences in means via randomization
 diff_mean_ht <- ncbirths_complete_habit %>% 
   # Specify weight vs. habit
-  ___ %>% 
-  # Null = no difference between means
-  ___ %>% 
-  # Shuffle labels 1000 times
-  ___ %>%
+  specify(___) %>% 
+  # Null = independence of variables
+  hypothesize(___) %>% 
+  # Generate 1000 permutations
+  generate(___) %>%
   # Calculate test statistic, nonsmoker then smoker
-  ___
+  calculate(___)
 ```
 
 <div id="smoking_3-hint">
 **Hint:** 
-- Call `specify()`, passing a formula of `weight` versus `habit`.
+- Call `specify()`, passing a formula of `weight ~ habit`.
 - Call `hypothesize()`, setting `null` to `"independence"`.
-- Call `generate()`, setting `reps` to `n_replicates` and `type` to `"permute"`.
+- Call `generate()`, setting `reps` to 1000 and `type` to `"permute"`.
 - Call `calculate()`, setting `stat` to `"diff in means"` and `order` to `c("nonsmoker", "smoker")`.
 </div>
 
+
 ```{r smoking_3-solution}
-# From previous steps
-ncbirths_complete_habit <- ncbirths %>%
-  filter(!is.na(habit))
-diff_mean_obs <- ncbirths_complete_habit %>%
-  group_by(habit) %>%
-  summarize(mean_weight = mean(weight)) %>%
-  pull() %>%
-  diff()
-
-n_replicates <- 1000
-
-# Generate 1000 differences in means via randomization
+# Generate 1000 differences in means via permutation
 diff_mean_ht <- ncbirths_complete_habit %>% 
   # Specify weight vs. habit
   specify(weight ~ habit) %>% 
-  # Null = no difference between means
+  # Null = independence of variables
   hypothesize(null = "independence") %>% 
-  # Shuffle labels 1000 times
-  generate(reps = n_replicates, type = "permute") %>%
+  # Generate 1000 permutations
+  generate(reps = 1000, type = "permute") %>%
   # Calculate test statistic, nonsmoker then smoker
   calculate(stat = "diff in means", order = c("nonsmoker", "smoker")) 
 ```
 
 ### 
 
-And finally,
+And finally, calculate the p-value for the hypothesis test. Use the `get_p_value()` function to survey how many of the permuted differences in means are as large or larger than the observed difference. 
 
-- Filter for rows where the bootstrap difference in means is less than or equal to the observed difference in means.
-- Summarize to calculate `one_sided_p_val` as the number of rows in the filtered dataset divided by the number of replicates.
-- Calculate `two_sided_p_val` from `one_sided_p_val`.
+- Use the previously calculated difference in means stored inside `diff_mean_obs` as the observed statistic. 
+- Use a "two-sided" alternative hypothesis to calculate the two-sided p-value. 
+- Compare the two-sided p-value to the one-sided ("greater") p-value. Is the one-sided p-value half of the two-sided?  
 
-
-```{r smoking_4, exercise=TRUE}
+```{r smoking_4-setup, include = FALSE}
 # From previous steps
 ncbirths_complete_habit <- ncbirths %>%
   filter(!is.na(habit))
+
 diff_mean_obs <- ncbirths_complete_habit %>%
   group_by(habit) %>%
   summarize(mean_weight = mean(weight)) %>%
   pull() %>%
   diff()
-n_replicates <- 1000
+
 diff_mean_ht <- ncbirths_complete_habit %>% 
   specify(weight ~ habit) %>% 
   hypothesize(null = "independence") %>% 
-  generate(reps = n_replicates, type = "permute") %>%
+  generate(reps = 1000, type = "permute") %>%
   calculate(stat = "diff in means", order = c("nonsmoker", "smoker")) 
-  
+```
+
+
+```{r smoking_4, exercise=TRUE}
+ 
 # Calculate p-value
-diff_mean_ht %>%
-  # Identify simulated test statistics at least as extreme as observed
-  ___ %>%
-  # Calculate p-value
-  ___(
-    one_sided_p_val = ___,
-    two_sided_p_val = ___
-  )
+  diff_mean_ht %>%
+  # use diff_mean as the observed statistic, and "two-sided" as the direction
+  get_p_value(obs_stat = , direction = " ") 
+
 ```
 
 <div id="smoking_4-hint">
 **Hint:** 
-- Call `filter()`, using the condition `stat` less than or equal to the observed median score difference.
-- Call `summarize()`, setting `one_sided_p_val` to the number of rows, `n()`, divided by the total number of replicates, `n_replicates`.
-- Inside `summarize()`, set `two_sided_p_val` to double `one_sided_p_val`.
+- Use `diff_mean_obs` as the input to `obs_stat`. 
+- Use a direction of `"two-sided"` for a two-sided hypothesis test. 
 </div>
 
 ```{r smoking_4-solution}
-# From previous steps
-ncbirths_complete_habit <- ncbirths %>%
-  filter(!is.na(habit))
-diff_mean_obs <- ncbirths_complete_habit %>%
-  group_by(habit) %>%
-  summarize(mean_weight = mean(weight)) %>%
-  pull() %>%
-  diff()
-n_replicates <- 1000
-diff_mean_ht <- ncbirths_complete_habit %>% 
-  specify(weight ~ habit) %>% 
-  hypothesize(null = "independence") %>% 
-  generate(reps = n_replicates, type = "permute") %>%
-  calculate(stat = "diff in means", order = c("nonsmoker", "smoker")) 
-  
 # Calculate p-value
-diff_mean_ht %>%
-  # Identify simulated test statistics at least as extreme as observed
-  filter(stat <= diff_mean_obs) %>%
-  # Calculate p-value
-  summarize(
-    one_sided_p_val = n() / n_replicates,
-    two_sided_p_val = 2 * one_sided_p_val
-  )
+  diff_mean_ht %>%
+  # use diff_mean as the observed statistic, and "two-sided" as the direction
+  get_p_value(obs_stat = diff_mean_obs, direction = "two-sided") 
+
 ```
 
 ### 
@@ -633,14 +548,14 @@ Wonderful! What does your p-value suggest about the relationship between smoking
 
 A natural next step in your analysis would be to quantify the difference between the two population means using a confidence interval. 
 Next, we outline the bootstrap scheme for estimating the difference between the two numerical population parameters. 
-The following exercises will reveal that implementing this scheme in R takes only a few tweaks to the pipelines using the infer package that we have been using for doing simulation based inference.
+The following exercises will reveal that implementing this scheme in `R` takes only a few tweaks to the pipelines using the infer package that we have been using for doing simulation based inference.
 
 ### Bootstrap CI for a difference
 
-> 1. Take a bootstrap sample *of each sample* - a random sample taken with replacement from each of the original samples, of the same size as each of the original samples.
-> 2. Calculate the bootstrap statistic - a statistic such as *difference* in means, medians, proportion, etc. computed based on the bootstrap samples.
-> 3. Repeat steps (1) and (2) many times to create a bootstrap distribution - a distribution of bootstrap statistics.
-> 4. Calculate the interval using the percentile or the standard error method.
+> 1. Take a bootstrap sample *of each sample* - a random sample taken with replacement from each of the original samples, of the same size as each of the original sample.
+> 2. Calculate the bootstrap statistic - a statistic such as *difference* in means, medians, proportion, etc. computed based on the bootstrap sample.
+> 3. Repeat steps (1) and (2) many times to create a bootstrap distribution - a sampling distribution of bootstrap statistics.
+> 4. Calculate the a confidence interval for the population parameter using the percentile or the standard error method.
 
 Constructing a bootstrap interval for the difference in two means is quite similar to constructing a bootstrap interval for a single mean. The only difference is that now we have two samples to bootstrap from. 
 
@@ -658,6 +573,13 @@ Now let's try some exercises.
 
 Let's construct a bootstrap interval for the difference in mean weights of babies born to smoker and non-smoker mothers. The `ncbirths_complete_habit` data frame you created earlier is available to use.
 
+### 
+
+First, generate 1500 bootstrap differences in means for birth weight by smoking habit.
+
+- `specify()` birth `weight` as the response and smoking `habit` as the explanatory variable.
+- `generate()` 1500 bootstrap resamples.
+- `calculate()` the difference in means, with order `"nonsmoker"` then `"smoker"`.
 
 ```{r smoking_bs-setup, include=FALSE}
 # Remove subjects with missing habit
@@ -665,29 +587,22 @@ ncbirths_complete_habit <- ncbirths %>%
   filter(!is.na(habit))
 ```
 
-### 
-
-First, generate 1500 bootstrap difference in means for birth weight by smoking habit.
-
-- Specify birth weight versus smoking habit.
-- Generate 1500 bootstrap replicates.
-- Calculate the difference in means, with order nonsmoker then smoker.
-
 
 ```{r smoking_bs, exercise=TRUE}
 # Generate 1500 bootstrap difference in means
 diff_mean_ci <- ncbirths_complete_habit %>%
   # Specify weight vs. habit
-  ___ %>%
+  specify(___) %>%
   # Generate 1500 bootstrap replicates
-  ___ %>%
+  generate(___) %>%
   # Calculate the difference in means, nonsmoker then smoker
-  ___
+  calculate(___)
 ```
 
 <div id="smoking_bs-hint">
-**Hint:** 
-- Call `specify()`, passing a formula of `weight` versus `habit`.
+**Hint:**  
+
+- Call `specify()`, passing a formula of `weight ~ habit`.
 - Call `generate()`, setting `reps` to `1500` and `type` to `"bootstrap"`.
 - Call `calculate()`, setting `stat` to `"diff in means"` and `order` to `c("nonsmoker", "smoker")`.
 </div>
@@ -705,27 +620,32 @@ diff_mean_ci <- ncbirths_complete_habit %>%
 
 ### 
 
-Then, calculate a 95% confidence interval for the bootstrap difference in mean birth weights using the percentile method.
+Then, calculate a 95% confidence interval for the bootstrap difference in mean birth weights using the `get_confidence_interval()` function. Use the `percentile` method.
 
-```{r smoking_bs_2, exercise=TRUE}
+```{r smoking_bs_2-setup, include = FALSE}
+# Remove subjects with missing habit
+ncbirths_complete_habit <- ncbirths %>%
+  filter(!is.na(habit))
+
 # From previous step
 diff_mean_ci <- ncbirths_complete_habit %>%
   specify(weight ~ habit) %>%
   generate(reps = 1500, type = "bootstrap") %>%
   calculate(stat = "diff in means", order = c("nonsmoker", "smoker"))
-  
+
+```
+
+```{r smoking_bs_2, exercise=TRUE}
 # Calculate the 95% CI via percentile method
 diff_mean_ci %>%
-  ___(
-    l = ___,
-    u = ___
-  )
+  get_confidence_interval(level = , type = " ")
 ```
 
 <div id="smoking_bs_2-hint">
-**Hint:** 
-- Call `summarize()`, setting `l` to the `0.025` quantile of `stat`.
-- The `probs` arguments for the `l` and `u` quantiles should add up to one.
+**Hint:**  
+
+- Specify the confidence `level` to be 0.95 for a 95% confidence interval. 
+- Specify the `type` of interval to be "percentile". 
 </div>
 
 ```{r smoking_bs_2-solution}
@@ -737,32 +657,31 @@ diff_mean_ci <- ncbirths_complete_habit %>%
   
 # Calculate the 95% CI via percentile method
 diff_mean_ci %>%
-  summarize(
-    l = quantile(stat, 0.025),
-    u = quantile(stat, 0.975)
-  )
+  get_confidence_interval(level = 0.95, type = "percentile")
 ```
 
 ### 
 
-Great! What is the interpretation of this interval?
+Great! How would you interpret this interval?
 
 
 ### Smoking during pregnancy and length of gestation
 
 Let's turn our attention to another variable, `weeks`, indicating the length of the pregnancy. Construct a bootstrap interval for the difference in median lengths of pregnancies of smoker and non-smoker mothers.
 
-Filter `ncbirths` for rows where smoking `habit` and length of pregnancy in `weeks` are both non-missing.
+Filter `ncbirths` for rows where __both__ smoking `habit` and length of pregnancy in `weeks` are not missing.
 
 
 ```{r smoking_bs_3, exercise=TRUE}
 # Filter for non-missing habit & non-missing weeks
 ncbirths_complete_habit_weeks <- ncbirths %>%
-  ___
+  filter(___, ___) 
 ```
 
 <div id="smoking_bs_3-hint">
-**Hint:** Call `filter()`, passing two conditions, using `!` and `is.na()` to keep only rows where `habit` and `weeks` are not `NA`.
+**Hint:** Call `filter()`, passing two conditions, using `!` and `is.na()` to keep only rows where `habit` and `weeks` are not `NA`.  
+
+Specifically, the conditions should look like: `!is.na(habit)` and `!is.na(weeks)`. These should be joined with a comma to indicate that they *both* need to be satisfied.  
 </div>
 
 ```{r smoking_bs_3-solution}
@@ -773,26 +692,28 @@ ncbirths_complete_habit_weeks <- ncbirths %>%
 
 ### 
 
-First, generate 1500 bootstrap difference in medians for pregnancy length in weeks by smoking habit.
+Now that we've eliminated the missing data, generate 1500 bootstrap difference in *medians* for pregnancy length in weeks by smoking habit.
 
-- Specify pregnancy length in `weeks` versus smoking `habit`.
-- Generate 1500 bootstrap replicates.
-- Calculate the difference in medians, with order nonsmoker then smoker.
+- `specify()` pregnancy length in `weeks` as the response variable and smoking `habit` as the explanatory variable.
+- `generate()` 1500 bootstrap resamples.
+- `calculate()` the difference in medians, with order `"nonsmoker"` then `"smoker"`.
+
+```{r smoking_bs_4-setup, include = FALSE}
+# Filter for non-missing habit & non-missing weeks
+ncbirths_complete_habit_weeks <- ncbirths %>%
+  filter(!is.na(habit), !is.na(weeks))
+```
 
 
 ```{r smoking_bs_4, exercise=TRUE}
-# From previous step
-ncbirths_complete_habit_weeks <- ncbirths %>%
-  filter(!is.na(habit), !is.na(weeks))
-
 # Generate 1500 bootstrap difference in medians
 diff_med_ci <- ncbirths_complete_habit_weeks %>%
   # Specify weeks versus habit
-  ___ %>%
+  specify(___) %>%
   # Generate 1500 bootstrap replicates
-  ___ %>%
+  generate(___) %>%
   # Calculate the difference in medians, nonsmoker then smoker
-  ___
+  calculate(___)
 ```
 
 <div id="smoking_bs_4-hint">
@@ -803,10 +724,6 @@ diff_med_ci <- ncbirths_complete_habit_weeks %>%
 </div>
 
 ```{r smoking_bs_4-solution}
-# From previous step
-ncbirths_complete_habit_weeks <- ncbirths %>%
-  filter(!is.na(habit), !is.na(weeks))
-
 # Generate 1500 bootstrap difference in medians
 diff_med_ci <- ncbirths_complete_habit_weeks %>%
   # Specify weeks versus habit
@@ -821,50 +738,40 @@ diff_med_ci <- ncbirths_complete_habit_weeks %>%
 
 Then, calculate a 92% confidence interval for the bootstrap difference in median pregnancy length in weeks using the percentile method.
 
-
-```{r smoking_bs_5, exercise=TRUE}
-# From previous step
+```{r smoking_bs_5-setup, include = FALSE}
+# Filter for non-missing habit & non-missing weeks
 ncbirths_complete_habit_weeks <- ncbirths %>%
   filter(!is.na(habit), !is.na(weeks))
+
 diff_med_ci <- ncbirths_complete_habit_weeks %>%
   specify(weeks ~ habit) %>%
   generate(reps = 1500, type = "bootstrap") %>%
   calculate(stat = "diff in medians", order = c("nonsmoker", "smoker"))
-
-# Calculate the 92% CI via percentile method
-diff_med_ci %>%
-  summarize(
-    l = ___,
-    u = ___
-  )
 ```
 
-<div id="smoking_bs_5-hint">
+
+```{r smoking_bs_5, exercise=TRUE}
+# Calculate the 95% CI via percentile method
+diff_med_ci %>%
+  get_confidence_interval(level = , type = " ")
+```
+
+<div id="smoking_bs_2-hint">
 **Hint:** 
-- Call `summarize()`, setting `l` to the `0.04` quantile of `stat`.
-- The `probs` arguments for the `l` and `u` quantiles should add up to one.
+- Specify the confidence `level` to be 0.92 for a 92% confidence interval. 
+- Specify the `type` of interval to be "percentile". 
 </div>
 
-```{r smoking_bs_5-solution}
-# From previous step
-ncbirths_complete_habit_weeks <- ncbirths %>%
-  filter(!is.na(habit), !is.na(weeks))
-diff_med_ci <- ncbirths_complete_habit_weeks %>%
-  specify(weeks ~ habit) %>%
-  generate(reps = 1500, type = "bootstrap") %>%
-  calculate(stat = "diff in medians", order = c("nonsmoker", "smoker"))
 
-# Calculate the 92% CI via percentile method
+```{r smoking_bs_5-solution}
+# Calculate the 95% CI via percentile method
 diff_med_ci %>%
-  summarize(
-    l = quantile(stat, 0.04),
-    u = quantile(stat, 0.96)
-  )
+  get_confidence_interval(level = 0.92, type = "percentile")
 ```
 
 ### 
 
-Well done! Quick mental check before you move on: What does 92% confident mean?
+Well done! Quick mental check before you move on: What do we mean when we say we're "92% confident"?
 
 ## Comparing means with a t-test
 
@@ -874,49 +781,47 @@ In this lesson we return to the American Community Survey data and compare avera
 ### A (more) standard measure of pay
 
 
-Instead of comparing average annual `income`, compare average `hrly_rate`:
+Instead of comparing average annual `income`, let's compare average `hrly_rate`. We'll calculate this by:
 
-> - assume 52 weeks in a year 
-> - `hrly_rate = income / (hrs_work * 52)`
+> - assuming there is 52 weeks in a year 
+> - using the formula `hrly_rate = income / (hrs_work * 52)`
 
-One obvious measure of pay is annual income. However instead of comparing annual incomes directly, we should adjust for the number of hours worked, and compare average hourly rates. So first, we create a new variable called hrly_rate. 
+One obvious measure of pay is annual income. However instead of comparing annual incomes directly, we should adjust for the number of hours worked, and compare average hourly rates. So first, we'll create a new variable called `hrly_rate`. 
 
 To do so we'll make the assumption that there are 52 weeks in a year, and calculate hourly rate as income divided by weekly hours times 52 weeks in the year.
 
-```{r}
+```{r, echo = TRUE}
 acs12 <- acs12 %>%
-  mutate(hrly_rate = income / (hrs_work * 52))
+  mutate(hrly_pay = income / (hrs_work * 52))
 ```
 
 ### Research question and hypotheses
 
 > Do the data provide convincing evidence of a difference between the average hourly rate of citizens and non-citizens in the US?
+
+ 
+> Let $\mu$ represent the true average hourly pay
 > 
-> Let $\mu = $ average hourly pay
+> $H_0: \mu_{citizen} = \mu_{non-citizen}$
 > 
-> $H\_0: \mu\_{citizen} = \mu\_{non-citizen}$
-> 
-> $H\_A: \mu\_{citizen} \ne \mu\_{non-citizen}$
+> $H_A: \mu_{citizen} \ne \mu_{non-citizen}$
 
 
 Our research question is "Do the data provide convincing evidence of a difference between the average hourly rate of citizens and non-citizens in the US?". We use a hypothesis test to answer this question.
 
-If mu is defined as average hourly pay in the population,
-
-The null hypothesis states there is no difference between the average hourly rates of citizens and non-citizens, and
-
-the alternative hypothesis follows from the research question, stating that there is a difference between the average hourly rates of citizens and non-citizens.
+If $\mu$ is defined as average hourly pay in the population, the null hypothesis states there is no difference between the average hourly rates of citizens and non-citizens. The alternative hypothesis follows from the research question, stating that there is a difference between the average hourly rates of citizens and non-citizens.
 
 
 ### Summary statistics
 
-```{r echo=TRUE}
+```{r}
 acs12 %>%
-  filter(!is.na(hrly_rate)) %>%
+  filter(!is.na(hrly_pay)) %>%
+  mutate(citizen = if_else(citizen == "no", "Non-citizen", "Citizen"), ) %>% 
   group_by(citizen) %>%
-  summarise(x_bar = round(mean(hrly_rate), 2),
-            s = round(sd(hrly_rate), 2),
-            n = length(hrly_rate)) 
+  summarise(x_bar = round(mean(hrly_pay), 2),
+            s = round(sd(hrly_pay), 2),
+            n = length(hrly_pay)) 
 ```
 
 Let's take a look at the relevant summary statistics. To do so, we group the data by citizenship status and then calculate mean, standard deviation, and sample size for each group. The observed average hourly rates for non-citizens and non-citizens are indeed different, but we want to know how they compare in the population, not just in this sample.
@@ -924,46 +829,57 @@ Let's take a look at the relevant summary statistics. To do so, we group the dat
 
 ### Conducting the test
 
+> __Null__:   
+> $H_0: \mu_{citizen} = \mu_{non-citizen}$  OR  $H_0: \mu_{citizen} - \mu_{non-citizen} = 0$ 
+>
+> __Alternative__:   
+$H_A: \mu_{citizen} \ne \mu_{non-citizen}$ OR $H_A: \mu_{citizen} - \mu_{non-citizen} \neq 0$
 
-```{r echo=TRUE}
-t.test(hrly_rate ~ citizen, data = acs12, null = 0, 
-       alternative = "two.sided")
-```
+We can use the `t_test` function from the infer package to conduct this test. The arguments for the `t_test()` function are as follows: 
 
-> - Null: 
->  - $H\_0: \mu\_{citizen} = \mu\_{non-citizen}$ 
->  - $H\_0: \mu\_{citizen} - \mu\_{non-citizen} = 0$ $\rightarrow$ `null = 0` 
-> - $H\_A: \mu\_{citizen} \ne \mu\_{non-citizen}$ $\rightarrow$ `alternative = "two.sided"` 
+1. the dataframe with the variables of interest 
 
+2. a formula of the form of `y  ~ x`, where `y` is the response variable and `x` is the explanatory variable 
 
-We can use the `t.test` function to conduct this test. The first argument is a formula of the form of y vs. x, in this case hourly rate vs. citizenship status. 
+3. the order of subtraction to be used (similar to what is used in the `calculate()` function) 
 
-Next we specify the data frame these variables live in, and then the null value and the alternative hypothesis.
+4. the direction of the alternative hypothesis (similar to the `direction` in the `calculate()` function)
 
-The null hypothesis says the two group means are equal to each other.
+5. if a confidence interval should be calculated (yes = `TRUE`, no = `FALSE`) 
 
-Or alternatively that the difference between the two groups means is 0, hence the null equals 0 in the function call.
+5. what confidence level should be used for the confidence interval 
 
-Since we're looking for a difference, the alternative is two.sided.
-
+Here, our null hypothesis alternative hypothesis says that there is a difference between the two groups means, which coincides with a `"two-sided"` hypothesis test. 
 
 ### 
 
-```{r echo=TRUE}
-t.test(hrly_rate ~ citizen, data = acs12, null = 0, 
-       alternative = "two.sided")
+```{r, echo = FALSE}
+acs12 <- acs12 %>% 
+  filter(!is.na(hrly_pay)) %>%
+  mutate(citizen = if_else(citizen == "no", "Non-citizen", "Citizen"))
+```
+
+```{r, echo=TRUE}
+acs12 %>%
+t_test(hrly_pay ~ citizen,  
+       order = c("Citizen", "Non-citizen"), 
+       alternative = "two-sided", 
+       conf_int = TRUE, 
+       conf_level = 0.95)
 ```
 
 The p-value of the test is 0.5637, which is higher than any reasonable significance level. Hence, we fail to reject the null hypothesis and conclude that the data do not provide convincing evidence of a difference between the average hourly rate of citizens and non-citizens in the US.
 
 ### Conditions
 
-> - Independence: 
->  - Observations in each sample should be independent of each other. 
->  - The two samples should be independent of each other. 
+> - Independence:  
+>   *  Observations in each sample should be independent of each other. 
+>   *  The two samples should be independent of each other. 
 > - Sample size / skew: The more skewed the original data, the higher the sample size required to have a symmetric sampling distribution. 
 
-![](images/chp3-vid3-hrly-rate-citizen-smaller.png)
+```{r, echo = FALSE, out.width= "50%"}
+knitr::include_graphics("images/chp3-vid3-hrly-rate-citizen-smaller.png")
+```
 
 Before we wrap up our discussion of comparing means across two groups, let's also review conditions for this test.
 
@@ -983,17 +899,18 @@ Using the `acs12` data, and specifically the variables `income`, `hrs_work`, and
 
 ### 
 
-First, filter `acs12` for rows where hourly pay, `hrly_pay`, and U.S. citizenship status, `citizen`, are both non-missing.
-
+First, filter `acs12` for rows where hourly pay (`hrly_pay`) and U.S. citizenship status (`citizen`) are __both__ non-missing.  
 
 ```{r citizens, exercise=TRUE}
 # Filter for non-missing hrly_pay and non-missing citizen
 acs12_complete_hrlypay_citizen <- acs12 %>%
-  ___
+  filter(___)
 ```
 
 <div id="citizens-hint">
-**Hint:** Call `filter()`, passing two conditions, using `!` and `is.na()` to keep only rows where `hrly_pay` and `citizen` are not `NA`.
+**Hint:** Call `filter()`, passing two conditions, using `!` and `is.na()` to keep only rows where `hrly_pay` and `citizen` are not `NA`.  
+
+Specifically, the arguments should look like: `!is.na(hrly_pay)` and `!is.na(citizen)`.  
 </div>
 
 ```{r citizens-solution}
@@ -1006,27 +923,28 @@ acs12_complete_hrlypay_citizen <- acs12 %>%
 
 Then, 
 
-- Get the number of rows in the full dataset, `acs12`.
-- Get the number of rows in the filtered dataset, `acs12_complete_hrlypay_citizen`.
-- Calculate the number of rows where at least one of `hrly_pay` and `citizen` was missing.
-- Calculate the proportion of missing rows where at least one of `hrly_pay` and `citizen` was missing.
+- Use `nrow()` to find the number of rows in the full dataset, `acs12`.
+- Compare that to the number of rows in the filtered dataset, `acs12_complete_hrlypay_citizen`.
+- Calculate the number of rows where at least one of `hrly_pay` and `citizen` obervations was missing.
+- Finally, calculate the proportion of missing rows where at least one of `hrly_pay` and `citizen` was missing.
+
+```{r citizens_2-setup, include = FALSE}
+acs12_complete_hrlypay_citizen <- acs12 %>%
+  filter(!is.na(hrly_pay), !is.na(citizen))
+```
 
 
 ```{r citizens_2, exercise=TRUE}
-# From previous step
-acs12_complete_hrlypay_citizen <- acs12 %>%
-  filter(!is.na(hrly_pay), !is.na(citizen))
-
-# Get nuber of rows in full dataset
-n_all <- ___
+# Get number of rows in full dataset
+rows_all <- ___
 
 # Get number of rows in filtered dataset
-n_non_missing <- ___
+rows_non_missing <- ___
 
-# Calculate number missing
-n_missing <- ___
+# Calculate number missing (total minus non-missing)
+rows_missing <- ___
 
-# Calculate proportion missing
+# Calculate proportion missing (missing divided by total)
 prop_missing <- ___
 
 # See the result
@@ -1035,27 +953,25 @@ prop_missing
 
 <div id="citizens_2-hint">
 **Hint:** 
+
 - Use `nrow()` to get the number of rows from a data frame.
-- The number of missing values is the total number of rows minus the number of non-missing rows.
-- The proportion of missing rows is the number of missing rows divided by the total number of rows.
+- The number of missing values is the total number of rows minus the number of non-missing rows (`rows_all - rows_non_missing`).
+- The proportion of missing rows is the number of missing rows divided by the total number of rows (`rows_missing / rows_all`). 
 </div>
 
 ```{r citizens_2-solution}
-# From previous step
-acs12_complete_hrlypay_citizen <- acs12 %>%
-  filter(!is.na(hrly_pay), !is.na(citizen))
 
 # Get number of rows in full dataset
-n_all <- nrow(acs12)
+rows_all <- nrow(acs12)
 
 # Get number of rows in filtered dataset
-n_non_missing <- nrow(acs12_complete_hrlypay_citizen)
+rows_non_missing <- nrow(acs12_complete_hrlypay_citizen)
 
-# Calculate number missing
-n_missing <- n_all - n_non_missing
+# Calculate number missing (total minus non-missing)
+rows_missing <- rows_all - rows_non_missing
 
-# Calculate proportion missing
-prop_missing <- n_missing / n_all
+# Calculate proportion missing (missing divided by total)
+prop_missing <- rows_missing / rows_all
 
 # See the result
 prop_missing
@@ -1063,50 +979,49 @@ prop_missing
 
 ### 
 
-Then, 
+Next calculate summary statistics for citizens and non-citizens. To do this, use the following steps: 
 
-- Group by U.S. citizenship status.
-- Summarize to calculate the mean of hourly pay, the standard deviation of hourly pay, and the number of rows in that citizenship group.
+1. `group_by()` citizenship status. 
+2. Use `summarize()` to calculate the mean of `hrly_pay`, the standard deviation of `hrly_pay`, and the number of observations in that citizenship group.
+
+```{r citizens_3-setup, include = FALSE}
+## Complete hourly pay and citizenship 
+acs12_complete_hrlypay_citizen <- acs12 %>% 
+  filter(!is.na(hrly_pay))
+```
 
 ```{r citizens_3, exercise=TRUE}
-# From previous step
-acs12_complete_hrlypay_citizen <- acs12 %>%
-  filter(!is.na(hrly_pay), !is.na(citizen))
-
 acs12_complete_hrlypay_citizen %>%
   # Group by citizen
-  ___ %>%
+  group_by(___) %>%
   summarize(
     # Calculate mean hourly pay
-    x_bar = ___,
+    mean_wage = ___,
     # Calculate std dev of hourly pay
-    s = ___,
+    sd_wage = ___,
     # Count number of rows
-    n = ___
+    n_obs = ___
   )
 ```
 
 <div id="citizens_3-hint">
-**Hint:** 
-- Call `group_by()`, passing `citizen`.
-- Call `summarize()`, setting `x_bar` to the mean of `hrly_pay`, `s` to the standard deviation of `hrly_pay`, and `n` to a call to `n()`.
+**Hint:**   
+
+- Call `group_by()`, passing `citizen` as the argument.
+- Call `summarize()`, using `mean()` to calculate the mean of `hrly_pay`, `sd()` to calculate the standard deviation of `hrly_pay`, and `n()` to find the number of observations in each group. 
 </div>
 
 ```{r citizens_3-solution}
-# From previous step
-acs12_complete_hrlypay_citizen <- acs12 %>%
-  filter(!is.na(hrly_pay), !is.na(citizen))
-
 acs12_complete_hrlypay_citizen %>%
   # Group by citizen
   group_by(citizen) %>%
   summarize(
     # Calculate mean hourly pay
-    x_bar = mean(hrly_pay),
+    mean_wage = mean(hrly_pay),
     # Calculate std dev of hourly pay
-    s = sd(hrly_pay),
+    s_wage = sd(hrly_pay),
     # Count number of rows
-    n = n()
+    n_obs = n()
   )
 ```
 
@@ -1114,78 +1029,93 @@ acs12_complete_hrlypay_citizen %>%
 
 Finally, plot a histogram of the `hrly_pay`, faceted by citizenship status.
 
-- Using `acs12_complete_hrlypay_citizen`, plot `hrly_pay` on the x axis.
+- Using `acs12_complete_hrlypay_citizen` dataset, plot `hrly_pay` on the x axis.
 - Add a histogram layer with a `binwidth` of 5.
+- Facet by the `citizen`ship status, using the `vars()` function. 
 
-
-```{r citizens_4, exercise=TRUE}
-# From previous steps
+```{r citizens_4-setup, include = FALSE}
+## Complete hourly pay and citizenship 
 acs12_complete_hrlypay_citizen <- acs12 %>%
   filter(!is.na(hrly_pay), !is.na(citizen))
-  
+
+```
+
+```{r citizens_4, exercise=TRUE}
 # Using acs12_complete_hrlypay_citizen, plot hrly_pay
 ___ +
   # Add a histogram layer
   ___ +
-  facet_grid(rows = vars(citizen))
+  facet_wrap(vars(___))
 ```
 
 <div id="citizens_4-hint">
-**Hint:** 
+**Hint:**    
+
 - Call ggplot() with `acs12_complete_hrlypay_citizen` as the dataset.
-- Inside aes(), map `x` to `hrly_pay`.
-- Add `geom_histogram()`, setting `binwidth` to 5.
+- Inside `aes()`, map `x` to `hrly_pay`.
+- Add `geom_histogram()`, setting `binwidth` to 5.  
+- Use `facet_wrap(vars(citizen))` to facet the plots by citizenship status. 
 </div>
 
 ```{r citizens_4-solution}
-# From previous steps
-acs12_complete_hrlypay_citizen <- acs12 %>%
-  filter(!is.na(hrly_pay), !is.na(citizen))
-  
 # Using acs12_complete_hrlypay_citizen, plot hrly_pay
-ggplot(acs12_complete_hrlypay_citizen, aes(x = hrly_pay)) +
+acs12_complete_hrlypay_citizen %>% 
+ggplot(aes(x = hrly_pay)) +
   # Add a histogram layer
   geom_histogram(binwidth = 5) +
-  facet_grid(rows = vars(citizen))
+  facet_wrap(vars(citizen))
 ```
 
 ### Estimating the difference of two means using a t-interval
 
-Earlier we used summary statistics and a visualization to compare the hourly pay of citizens vs. non-citizens. In this exercise we estimate the difference between the average hourly pay between these two groups. 
+Earlier we used summary statistics and a visualization to compare the hourly pay of citizens vs. non-citizens. In this exercise we estimate the difference between the average hourly pay between these two groups with a 90% confidence interval. 
 
 The `acs12_complete_hrlypay_citizen` is already loaded for you.
 
-- Run a t-test to find a confidence interval for the difference in average hourly pay, `hrly_pay` between citizen and non-citizens, `citizen` in the `acs12_complete_hrlypay_citizen` dataset. Assign to `test_results`.
+- Run a t-test to find a confidence interval for the difference in average hourly pay, `hrly_pay` between citizen and non-citizens, `citizen` in the `acs12_complete_hrlypay_citizen` dataset. Assign the test results to the `test_results` object.
 
+**Remember** the `t_test()` function behaves similarly to the `calculate()` function! 
 
-```{r citizens_5-setup, include=FALSE}
-# Create new variable: hrly_pay
+```{r citizens_5-setup, include = FALSE}
+## Complete hourly pay and citizenship 
 acs12_complete_hrlypay_citizen <- acs12 %>%
-  mutate(hrly_pay = income / (hrs_work * 52)) %>%
-  filter(
-    !is.na(hrly_pay),
-    !is.na(citizen)
-  )
+  filter(!is.na(hrly_pay), !is.na(citizen))
 ```
 
 ```{r citizens_5, exercise=TRUE}
-# Construct 95% CI using a t-test
-test_results <- ___
+# Construct 90% CI using a t-test
+test_results <- acs12_complete_hrlypay_citizen %>% 
+  t_test(___ ~ ___, 
+            order = c("Citizen", " "), 
+            alternative = " ", 
+            conf_int = TRUE, 
+            conf_level = )
 
 # See the results
 test_results
 ```
 
-<div id="citizens_4-hint">
-**Hint:** Call `t.test()`, passing a formula of `hrly_pay` versus `citizen` and setting `data` to `acs12_complete_hrlypay_citizen`.
+<div id="citizens_5-hint">
+**Hint:**   
+
+- Use the formula of `hrly_pay ~ citizen` 
+- Add "Non-citizen" to the order of subtraction 
+- Specify the alternative to be "two-sided"  
+- Specify the confidence level to be 0.90
 </div>
 
 ```{r citizens_5-solution}
-# Construct 95% CI using a t-test
-test_results <- t.test(hrly_pay ~ citizen, data = acs12_complete_hrlypay_citizen)
+# Construct 90% CI using a t-test
+test_results <- acs12_complete_hrlypay_citizen %>% 
+  t_test(hrly_pay ~ citizen, 
+            order = c("Citizen", "Non-citizen"), 
+            alternative = "two-sided", 
+            conf_int = TRUE, 
+            conf_level = 0.90)
 
 # See the results
 test_results
+ 
 ```
 
 ## Congratulations!

--- a/07-inference-for-numerical-responses/03-lesson/07-03-lesson.Rmd
+++ b/07-inference-for-numerical-responses/03-lesson/07-03-lesson.Rmd
@@ -496,7 +496,7 @@ And finally, calculate the p-value for the hypothesis test. Use the `get_p_value
 
 - Use the previously calculated difference in means stored inside `diff_mean_obs` as the observed statistic. 
 - Use a "two-sided" alternative hypothesis to calculate the two-sided p-value. 
-- Compare the two-sided p-value to the one-sided ("greater") p-value. Is the one-sided p-value half of the two-sided?  
+- Compare the two-sided p-value to the one-sided ("less") p-value. Is the one-sided p-value half of the two-sided?  
 
 ```{r smoking_4-setup, include = FALSE}
 # From previous steps
@@ -854,8 +854,7 @@ Here, our null hypothesis alternative hypothesis says that there is a difference
 ### 
 
 ```{r, echo = FALSE}
-acs12 <- acs12 %>% 
-  filter(!is.na(hrly_pay)) %>%
+acs12 <- acs12 %>%
   mutate(citizen = if_else(citizen == "no", "Non-citizen", "Citizen"))
 ```
 

--- a/07-inference-for-numerical-responses/04-lesson/07-04-lesson.Rmd
+++ b/07-inference-for-numerical-responses/04-lesson/07-04-lesson.Rmd
@@ -15,6 +15,8 @@ library(tidyverse)
 library(infer)
 library(broom)
 library(emo)
+library(openintro)
+library(magrittr)
 
 # knitr options ----------------------------------------------------------------
 
@@ -30,15 +32,15 @@ knitr::opts_chunk$set(fig.align = "center",
 gss <- read_csv("data/gss_wordsum_class.csv")
 ```
 
-## Vocabulary score vs. self identified social class
+## Vocabulary score vs. self-identified social class
 
-### Vocabulary score and self identified social class
+### Vocabulary score and self-identified social class
 
 So far in this tutorial, we discussed inference on a single mean as well as inference for comparing two means. Next we move on to comparing many means simultaneously.
 
 
 > - `wordsum`: 10 question vocabulary test (scores range from 0 to 10)
-> - `class`: self identified social class (lower, working, middle, upper)
+> - `class`: self-identified social class (lower, working, middle, upper)
 
 |   | `wordsum`|`class` |
 |:--|:---------|:-------|
@@ -85,16 +87,16 @@ ggplot(data = gss, aes(x = wordsum)) +
   geom_histogram(binwidth = 1)
 ```
 
-The distribution of vocabulary scores is shown in this histogram. The scores range between 0 and 10. The distribution is centered at 5, and looks roughly symmetric.
+The distribution of vocabulary scores is shown in this histogram. The scores range between 0 and 10. The distribution is centered around 6, and looks roughly symmetric. There is a bit of a left skew, but nothing overly dramatic. 
 
-### Self identified social class: `class`
+### self-identified social class: `class`
 
 
 *If you were asked to use one of four names for your social class, which would you say you belong in: the lower class, the working class, the middle class, or the upper class?*
  
 ```{r echo=TRUE}
-ggplot(data = gss, aes(x = wordsum)) +
-  geom_histogram(binwidth = 1)
+ggplot(data = gss, aes(x = class)) +
+  geom_bar()
 ```
 
 And the distribution of social class is shown in this bar plot.
@@ -105,34 +107,30 @@ Time to put this into practice.
 
 ### EDA for vocabulary score vs. social class
 
-Before we conduct inference, we should take a look at the distributions of vocabulary scores across the levels of (self identified) social class.
+Before we conduct inference, we should take a look at the distributions of vocabulary scores across the levels of (self-identified) social class.
 
 
 
 - Using `gss`, plot the distribution of vocabulary scores, `wordsum`.
 - Make this a histogram, using an appropriate binwidth.
 - Facet this histogram, wrapping by social class level.
-- *Look at the plot! Compare the distributions of vocabulary scores across the levels of (self identified) social class.*
 
-
-```{r vocabulary-setup}
-```
-
+*Look at the plot! Compare the distributions of vocabulary scores across the levels of (self-identified) social class.*
 
 ```{r vocabulary, exercise=TRUE}
 # Using gss, plot wordsum
-ggplot(___, mapping = ___) +
+ggplot(data = ___, mapping = aes(___)) +
   # Add a histogram layer
   ___ +
   # Facet by class
-  facet_wrap(___)
+  facet_wrap(vars(___))
 ```
 
 <div id="vocabulary-hint">
 **Hint:** 
-- Use `gss` as the plot's data argument, then call `aes()`, mapping `x` to `wordsum`.
-- Add a histogram layer with `geom_histogram()`. Vocabulary scores can only be whole numbers, so it doesn't make sense to have bins narrower than one point.
-- The faceting formula can be specified using `~ class`.
+- Use `gss` as the plot's `data` argument, then map `x` to `wordsum` in c`aes()`. 
+- Add a histogram layer with `geom_histogram()`. Vocabulary scores can only be whole numbers, so it doesn't make sense to have a `binwidth` narrower than one (1) point.
+- The faceting formula can be specified using `vars(class)`.
 </div>
 
 ```{r vocabulary-solution}
@@ -141,12 +139,12 @@ ggplot(data = gss, mapping = aes(x = wordsum)) +
   # Add a histogram layer
   geom_histogram(binwidth = 1) +
   # Facet by class
-  facet_wrap(~ class)
+  facet_wrap(vars(class))
 ```
 
 ### 
 
-Great start to the last lesson of the tutorial! Before you move on, make sure you've compared all attributes of the distributions: shape, center, spread, unusual observations.
+Great start! Before you move on, make sure you've compared all attributes of the distributions: shape, center, spread, unusual observations.
 
 ### Comparing many means, visually
 
@@ -196,32 +194,21 @@ ggplot(df, aes(x = x, y = y)) +
 
 In this lesson we'll formally introduce analysis of variance, in other words ANOVA.
 
-We're going to start our discussion with variability partitioning, which means considering different factors that contribute to variability in our response variable.
+We're going to start our discussion with reviewing the hypotheses for an ANOVA. Next, we'll discuss variability partitioning, considering the different factors that contribute to variability in our response variable.
 
 
-
-### Marathon finishing times
-
-![](images/runners.001.png)
-
-Consider runners in a marathon. Not everybody is going to finish at the same time. The variability in their finishing times will likely be due to a variety of factors. One of them might be how much they trained for this marathon. However, there will certainly be other factors as well: physical characteristics, previous running experience, sleep, warm up exercises, and so on and so forth.
-
-Suppose we're interested in evaluating how strongly training is associated with finishing time. In order to do so we partition the total variability in finishing times as variability due to this variable, and variability due to all other factors. We're going to build up on this idea of variability partitioning, and the F statistic we introduced earlier, to work our way through the analysis of variance output.
+### ANOVA for vocabulary scores vs. self-identified social class
 
 
-
-### ANOVA for vocabulary scores vs. self identified social class
-
-
-> $H\_0$: The average vocabulary score is the same across all social classes, $\mu\_{lower} = \mu\_{working} = \mu\_{middle} = \mu\_{upper}$.
+> $H_0$: The average vocabulary score is the same across all social classes;  
+> $\mu_{lower} = \mu_{working} = \mu_{middle} = \mu_{upper}$.
 > 
-> $H\_A$: The average vocabulary scores differ between at least one pair of social classes.
+> $H_A$: The average vocabulary score for at least one social class differs from the others. 
 
 
 Let's quickly remind ourselves of the data we're working with from the General Social Survey on vocabulary scores, a numerical variable, and social class, a categorical variable with four levels.
 
-Our null hypothesis is that the average vocabulary score is the same across all social classes, and the alternative hypothesis is that average vocabulary scores differ between at least one pair of social classes.
-
+Our null hypothesis is that the average vocabulary score is the same across all social classes, and the alternative hypothesis is that average vocabulary score is different for at least one social class. Notice that the alternative hypothesis __is not__ that the scores for all of the social classes are different! The negation (opposite) of assuming every group is equal is assuming that at least one group is different.
 
 
 ### Variability partitioning
@@ -231,27 +218,26 @@ Our null hypothesis is that the average vocabulary score is the same across all 
 > 
 > - Variability that can be attributed to differences in social class - **between group** variability 
 > 
-> - Variability attributed to all other factor - **within group** variability 
+> - Variability attributed to factors within a group - **within group** variability 
+> 
+
 
 
 Let's outline this idea of variability partitioning:
 
 The total variability in vocabulary scores times is basically the variance in vocabulary scores of all respondents to the general social survey.
 
-We partition the variability into two: 
+We partition the variability into two sets: 
 
-Variability that can be attributed to differences in social class,
-and variability attributed to all other factors.
+- Variability that can be attributed to differences in social class, and variability attributed to other factors.
 
-Variability attributed to social class is called "between group" variability, since social class is the grouping variable in our analysis.
+- Variability attributed to social class is called "between group" variability, since social class is the grouping variable in our analysis.
 
-The other portion of the variability is what we're not interested in, and, in fact, it is somewhat of a nuisance factor for us since if everyone within a certain social class scored the same then we would have no variability attributed the other factors. This portion of the variability is called "within group variability".
-
-
+Variability attributed to differences within each social group is called "within group" variability. This variability is not what we are interested in and is somewhat of a nuisance factor. If everyone within a certain social class had the same vocabulary score, then we would have no within group variability and we would be able to more easily compare the vocabulary scores across groups. However, this is almost never the case, and we need to account for the variability within the groups we are interested in. 
 
 ### ANOVA output
 
-Here is a look at ANOVA output. The first row is about the between group variability, and the second row is about the within group variability. We often refer to the first row as the "group" row, and the second row as the "error" row. Next we'll go through some of the values on the anova table and what they mean.
+Here is a look at what the output of an ANOVA model looks like. The first row is about the between group variability, and the second row is about the within group variability. We often refer to the first row as the "group" row, and the second row as the "error" row. Next we'll go through some of the values on the ANOVA table and describe what they mean.
 
 
 ```{r echo=TRUE}
@@ -262,122 +248,178 @@ aov(wordsum ~ class, gss) %>%
 
 ### Sum of squares
 
-```{r}
-aov(wordsum ~ class, gss) %>%
-  tidy()
-```
-
-> - $SST = 236.5644 + 2869.8003 = 3106.365$ - Measures the total variability in the response variable 
-> - Calculated very similarly to variance (except not scaled by the sample size) 
-> - Percentage of explained variability = $\frac{236.5644}{3106.365} = 7.6\%$ 
-
 Let's start with the Sum of Squares column. 
 
 These values measure the variability attributed to the two components: the variability in vocabulary scores explained by social class and the unexplained variability -- that is, unexplained by the explanatory variable in this particular analysis. 
-The sum of these two values would make up sum of squares total, which measures the total variability in the response variable, in this case this would be the total variability of the vocabulary scores. 
-This value is calculated very similarly to the variance, except that it's not scaled it by the same size. More specifically, this is calculated as the total squared deviation from the mean of the response variable.
-One statistic not presented on the ANOVA table that might be of interest is the percentage of the variability in vocabulary scores explained by the social class variable. We can find this as the ratio of the sum of squares for class divided by the total sum of squares. In this case, 7.6% of the variability in vocabulary scores is explained by self identified social class. This value is the R-squared value we would obtain if we set up this analysis as a regression predicting vocabulary score from social class.
+
+The sum of these two values makes up sum of squares total, which measures the total variability in the response variable, in this case this would be the total variability of the vocabulary scores. 
+
+This value is calculated similarly to the variance, except that it's not scaled it by the sample size. More specifically, this is calculated as the total squared deviation from the mean of the response variable.
+
+One statistic not presented on the ANOVA table that might be of interest is the percentage of the variability in vocabulary scores explained by the social class variable. We can find this as the ratio of the sum of squares for class divided by the total sum of squares.  
+
+> - $SST = 236.5644 + 2869.8003 = 3106.365$ -- Measures the total variability in the response variable 
+> - Percentage of explained variability = $\frac{236.5644}{3106.365} = 7.6\%$ 
+
+In this case, 7.6% of the variability in vocabulary scores is explained by self-identified social class. This is the same as the $R^2$ value we would obtain if instead performed a linear regression, explaining vocabulary score with self-identified social class.
+
+
+### F-distribution
+
+ANOVA uses a test statistic $F$, which represents a standardized ratio of variability in the sample means relative to the variability within the groups. If $H_0$ is true and the model conditions are not violated, the statistic ($F$) follows an $F$-distribution with parameters $df_1 = groups -1$ and $df_2 = n - groups$. 
+
+In the plot below, you see that the $F$-distribution is right skewed! There are no negative values on the $F$-distribution! Thus, for every hypothesis test, the upper tail of the $F$-distribution is used to calculate the p-value.
+
+Similar to the $t$- distribution, the $F$-distribution is defined by degrees of freedom. Except, now there are two different degrees of freedom, the degrees of freedom of the groups and the degrees of freedom of the residuals. 
+
+These degrees of freedom are called the "numerator" and "denominator" degrees of freedom, since they correspond to the mean squares used in the calculation of the $F$-statistic. The "numerator" degrees of freedom is the number of groups you have minus 1 (here: 4 - 1). The "denominator" degrees of freedom is the total number of observations minus the number of groups (here: 795 - 4). 
+
+A plot of the $F$-distribution used to calculate the p-value for this hypothesis test is shown below. 
+
+```{r, echo = FALSE}
+values <- rf(100000, df1 = 3, df2 = 791) %>% 
+  tibble()
+
+obs_stat <- aov(wordsum ~ class, gss) %>%
+  tidy() %>% 
+  filter(term == "class") %>% 
+    select(statistic) %>% 
+  pull()
+
+values %>% 
+ggplot(aes(x = .)) + 
+  geom_density() + 
+  xlim(c(0, 25)) + 
+  labs(x = "F-statistic", 
+       y = "Density", 
+       title = "F-distribution with 3 and 791 Degrees of Freedom")
+
+```
 
 
 ### F-statistic
+
+The $F$-statistic is calculated as the ratio between the “between” and “within” group variabilities, assuming all groups means were equal. Here when we talk about "variability" we are scaling the sum of squares for each group by its degrees of freedom. This gets us to the mean square values seen in the table. The ratio of these mean squares is how the $F$-statistic is calculated. 
+
+The p-value is the area under the $F$-distribution beyond the observed $F$-statistic. We draw conclusions based on this p-value just like with any other hypothesis test we've seen so far.
+
 
 ```{r}
 aov(wordsum ~ class, gss) %>%
   tidy()
 ``` 
 
-> F-statistic = 21.73467 = $\frac{between~group~var}{within~group~var}$
+> F-statistic = $\frac{\frac{between~group~var}{group~size}}{\frac{within~group~var}{n - group~size}} = \frac{\frac{236.5644}{3}}{\frac{2869.8003}{791}} = \frac{78.854810}{3.628066} = 21.73467$
 
-![](images/wordsum_pval.png)
+</br> 
 
-The main values of interest on this table are the F-statistic, which is calculated as the ratio between the “between” and “within” group variabilities if in fact the means of all groups are equal, and 
- the p-value, which is the area under the F-distribution beyond the observed F-statistic. We draw conclusions based on this p-value just like with any other hypothesis test we've seen so far.
+The same $F$-distribution as above is shown below, with the observed $F$-statistic is displayed in red. 
+
+```{r, echo = FALSE}
+values <- rf(100000, df1 = 3, df2 = 791) %>% 
+  tibble()
+
+obs_stat <- aov(wordsum ~ class, gss) %>%
+  tidy() %>% 
+  filter(term == "class") %>% 
+    select(statistic) %>% 
+  pull()
+
+values %>% 
+ggplot(aes(x = .)) + 
+  geom_density() + 
+  xlim(c(0, 25)) + 
+  labs(x = "F-statistic", 
+       y = "Density", 
+       title = "F-distribution with 3 (numerator) and 791 (denominator) \n Degrees of Freedom") + 
+  geom_vline(xintercept = obs_stat, color = "red", linetype = "dashed")
+
+```
 
 Time to put this into practice.
 
-### ANOVA for vocabulary score vs. (self identified) social class
+### ANOVA for evaluation score vs. rank of professor
 
-Let's conduct the ANOVA for evaluating whether there is a difference in the average vocabulary scores between the levels of (self identified) social class.
+Let's conduct the ANOVA for evaluating whether there is a difference in the average evaluation score between the different ranks of professors at the University of Texas at Austin.
 
-- Run the ANOVA with the `aov()` function, and store the resulting object as `aov_wordsum_class`.
+Use the `evals` data to perform an ANOVA for evaluation `score` based on professor `rank`. Use the following steps: 
+
+- Use the `aov()` to perform the ANVOA, with inputs `score` and `rank`. 
+- Store the resulting object as `aov_evals_rank`.
 - View a `tidy()` output of this object.
-- *Interpret the result in context of the data and the research question. Use a 5% significance level.*
+
 
 ```{r vocabulary_2, exercise=TRUE}
-# Run an analysis of variance on wordsum vs. class
-aov_wordsum_class <- ___
+# Run an analysis of variance on score vs. rank
+aov_evals_rank <- aov(___, data = ___)
 
 # Tidy the model
-tidy(aov_wordsum_class)
+tidy(aov_evals_rank)
 ```
 
 <div id="vocabulary_2-hint">
 **Hint:** 
-- Call `aov()`, passing a formula of `wordsum` versus `class` and setting `data` to `gss`.
-- Call `tidy()`, passing the AOV model.
+- Call `aov()`, passing a formula of `score ~ rank`, using the `evals` dataset.
+- Call `tidy()`, passing the `aov_evals_rank` AOV model.
 </div>
 
+
 ```{r vocabulary_2-solution}
-# Run an analysis of variance on wordsum vs. class
-aov_wordsum_class <- aov(wordsum ~ class, data = gss)
+# Run an analysis of variance on score vs. rank
+aov_evals_rank <- aov(score ~ rank, data = evals)
 
 # Tidy the model
-tidy(aov_wordsum_class)
+tidy(aov_evals_rank)
+
 ```
 
-### 
+Interpret the result in context of the data and the research question. If needed, use a 2.5% significance level.  
 
-Great! What is the conclusion of the hypothesis test?
+Would your conclusion change if you had used a 10% significance level?
+
 
 ### Conditions for ANOVA
 
-Just like any other statistical inference method we've encounter so far, there are conditions that need to be met for anova as well.
+Just like any other statistical inference method we've encounter so far, there are mathematical conditions that need to be met for an ANOVA as well. Since we cannot mathematically "prove" that these conditions have been "met," we will use a careful eye to evaluate the degree to which each condition may be violated. 
+
+There are three main conditions for ANOVA. The first one is independence. Within groups the sampled observations must be independent of each other, and between groups the groups must be independent of each other as well. 
+
+We also need approximate normality, that is the distributions within each group should be nearly normal. 
+
+Finally, we have the condition of constant variance. That is the variability of the distributions of the response variable within each group should have roughly the same variance.
 
 > - **Independence:**
 >     - within groups: sampled observations must be independent 
->     - between groups: the groups must be independent of each other (non-paired) 
+>     - between groups: the groups must be independent of each other
 > - **Approximate normality:** distribution of the response variable should be nearly normal within each group
 > - **Equal variance:** groups should have roughly equal variability
-
-There are three main conditions for ANOVA. The first one is independence.
-Within groups the sampled observations must be independent of each other,
-and between groups the groups must be independent of each other as well
-We also need approximate normality, that is the distributions within each group should be nearly normal
-and constant variance, that is the variability of the distributions of the response variable within each group should have roughly equal variance.
 
 Next we'll discuss each condition in more detail.
 
 ### Independence
 
+Let's start with the independence condition.
+
+Within groups we want the samples observations to be independent. We can assume this is the case if we have random sampling. For experiments with random assignment but without random sampling, researchers would need to carefully consider if any of the observations could be related. For studies with small sample sizes, we need to be sure that the each sample size is less than 10% of its respective population. This condition is always important, but can be difficult to check if we don't have sufficient information on how the study was designed and data were collected.
+
+Between groups we want the groups to be independent of each other. This requires carefully considering whether there is a paired structure between the groups. If the answer is yes, this is not the end of the world, but it requires a different, slightly more advanced version of ANOVA. 
+
 > - **Within groups:** Sampled observations must be independent of each other
->     - Random sample / assignment
+>     - Random sample 
 >     - Each $n_j$ less than 10% of respective population always important, but sometimes difficult to check
 >      
 > - **Between groups:** Groups must be independent of each other  
 >     - Carefully consider whether the groups may be dependent 
-
-
-Let's start with the independence condition.
-
-Within groups we want the samples observations to be independent, which we can assume to the case if we have random sampling or assignment, and if each sample size is less than 10% of its respective population, if we have conducted a stratified sampling process without replacement. This condition is always important, but can be difficult to check if we don't have sufficient information on how the study was designed and data were collected.
-
-Between groups we want the groups to be independent of each other. This requires carefully considering whether there is a paired structure between the groups. if the answer is yes, this is not the end of the world, but it requires a different, slightly more advanced version of ANOVA, called repeated measures ANOVA, for a correct analysis of such data. So the ANOVA we are learning in this tutorial will only work in circumstances where the groups are independent.
+>     - Cannot have paired (or repeated) obervations in the groups
 
 
 ### Approximately normal
 
-We also need the distribution of the response variable within to be approximately normal. And this condition is especially important when the sample sizes are small. We can check this condition using appropriate visualizations, which you'll get to do in the following exercises.
-
-> - Distribution of response variable within each group should be approximately normal
-> - Especially important when sample sizes are small
-> - Check with visuals
+We also need the distribution of the response variable within each group to be approximately Normal. This condition is especially important when the sample sizes are small! We can check this condition using appropriate visualizations, which you'll get to do in the following exercises.
 
 ### Constant variance
 
-Lastly we need constant variance across groups, in other words variability should be consistent across groups. A commonly used term for this is homoscedasticity. This condition is especially important when the sample sizes differ between groups. We can use visualizations and/or summary statistics to check this condition.
-
-> - Variability should be consistent across groups (homoscedasticity)
-> - Especially important when sample sizes differ between groups
+Lastly we need constant variance across groups, in other words variability should be consistent across groups. This condition is especially important when the sample sizes differ between groups! We can use visualizations and/or summary statistics to check this condition.
 
 Next we'll check the conditions for the vocabulary score vs. social class ANOVA that we have been working on.
 
@@ -385,9 +427,9 @@ Next we'll check the conditions for the vocabulary score vs. social class ANOVA 
 
 ```{r quiz_2}
 question("Which of the following provides the most complete information for checking the normality condition for the ANOVA for evaluating whether there are differences between the average vocabulary scores across social classes?",
-  correct = "Correct! A histogram shows you the shape of the distribution.",
+  correct = "Correct! A violin plot shows you the shape of the distribution.",
   allow_retry = TRUE,
-  answer("Histogram of vocabulary scores, faceted by social class", correct = TRUE),
+  answer("Violin plot of vocabulary scores, faceted by social class", correct = TRUE),
   answer("Box plot of vocabulary scores, faceted by social class", message = "No. A box plot only gives you 5 metrics about the distribution of a variable, plus the positions of the outliers."),
   answer("Means and standard deviations of vocabulary scores in each social class", message = "No. This only gives you two metrics about the distribution of the scores, but doesn't tell you about the shape of the distribution."),
   answer("Number of modes of vocabulary scores in each social class", message = "No. This only gives you details of the modality of the distribution of the scores, but doesn't show you the shape of the distribution.")
@@ -398,28 +440,27 @@ question("Which of the following provides the most complete information for chec
 
 In addition to checking the normality of distributions of vocabulary scores across levels of social class, we need to check that the variances from each are roughly constant.
 
+In the exercise below, you'll calculate the standard deviations of each social class. To do this: 
 
+1. `group_by()` social `class` 
+2 `summarize()` each group with the standard deviations (`sd()` ) of vocabulary scores (`wordsum`)
+3. Store these summaries in a column named `sd_wordsum`. 
 
-- Group by social class.
-- Summarize to calculate the standard deviations of vocabulary scores, storing in a column named `std_dev_wordsum`. 
-- *Verify the constant variance condition.*
+Use these calculations to decide if it seems reasonable to assume that the groups have equal variability. 
 
-
-```{r vocabulary_3-setup, include=FALSE}
-```
 
 ```{r vocabulary_3, exercise=TRUE}
 gss %>%
   # Group by class
-  ___ %>%
+  group_by(___) %>%
   # Calculate the std dev of wordsum as std_dev_wordsum
-  ____
+  summarize(___ = ___)
 ```
 
 <div id="vocabulary_3-hint">
 **Hint:** 
-- Call `group_by()`, passing `class`.
-- Call `summarize()`, setting `std_dev_wordsum` to the standard deviation of `wordsum`.
+- Call `group_by()`, passing `class` as the argument.
+- Call `summarize()`, setting `std_dev_wordsum` to `sd(wordsum)`.
 </div>
 
 ```{r vocabulary_3-solution}
@@ -427,12 +468,41 @@ gss %>%
   # Group by class
   group_by(class) %>%
   # Calculate the std dev of wordsum as std_dev_wordsum
-  summarize(std_dev_wordsum = sd(wordsum))
+  summarize(sd_wordsum = sd(wordsum))
 ```
 
 ### 
 
-So, what do you think? Is the constant variance condition met?
+So, what do you think? Is the equal variance condition violated? 
+
+Let's see what these standard deviations *look* like. 
+
+Create side-by-side violin plots of the distribution of `wordsum` across the different self-identified social `class`es. Color the violins based on the `class`.  
+
+```{r vocabulary_4, exercise=TRUE}
+gss %>%
+  # Map wordsum to the y-axis and class to the x-axis
+  ggplot(aes(x = ___, y = ___)) +
+  # Add violins to the plot and color by class
+  geom_violin(aes(fill = ___))
+```
+
+<div id="vocabulary_4-hint">
+**Hint:** 
+- Call `ggplot()`, passing `wordsum` to the `y` variable and `class` to the `x` variable. 
+- Change the colors of the violins by specifying `class` as the `color` variable. 
+</div>
+
+```{r vocabulary_4-solution}
+gss %>%
+  # Map wordsum to the y-axis and class to the x-axis
+  ggplot(aes(x = class, y = wordsum)) +
+  # Add violins to the plot and color by class
+  geom_violin(aes(fill = class))
+```
+
+So, what do you think now? Is the equal variance condition violated? 
+
 
 ## Post-hoc testing
 
@@ -440,61 +510,47 @@ So far we've introduced ANOVA as a method for comparing many means to each other
 
 ### Which means differ?
 
-> - Two sample t-tests for differences in each possible pair of groups
-> - Multiple tests → inflated Type 1 error rate
-> - Solution: use modified significance level
+What we're talking about is performing lots and lots of $t$-test, testing which of the groups are different. Unfortunately, performing lots and lots of hypothesis test has some major downsides. The main one we are worried about is the inflation in the Type I error rate. 
+If you remember back to the [Errors in hypothesis testing tutorial](https://openintro.shinyapps.io/ims-05-introduction-to-statistical-inference-03), a Type I error is when we reject the null hypothesis when it is true. We specify a threshold for the percentage of times we are willing to make this type of error by selecting an $\alpha$. So, an $\alpha$ of 0.05, says we are willing to make a Type I error 5% of the time. 
 
-And when doing so we're going to discuss how to control the Type I error rate that would be inflated by doing many pairwise tests in the quest for identifying the groups whose means are significantly different from each other.
+If we think about performing multiple $t$-tests all at a 5% significance level, then our error rate begins to grow. Specifically, if we perform 10 tests all with an $\alpha$ of 0.05, the probability of not making a Type I error for each test is $(1- \alpha)$. If we then compute the overall probability of not making a Type I error we'd have $1 - (1- \alpha)^n \approx n \cdot \alpha.$ For 10 tests at a $\alpha$ of 0.05, the probability of not making a Type I error is approximately 50%. That's not very unlikely!  
 
-Remember that to determine whether two means are different from each other we use t-tests, with each test you incur a possibility of a Type 1 error. The probability of committing a Type 1 error is the significance level of the test, which is often set at 5%.
+So, what we're interested in is controlling the Type I error rate, when performing many pairwise tests in the quest for identifying the groups whose means are "significantly" different from each other.
 
-When you do multiple tests to compare each possible pairing of groups to each other, then you inflate your overall Type 1 error rate, which is an undesirable outcome
+Fortunately, there is a simple solution to this problem: use a modified significance level. 
 
-However there's a simple solution: use a modified significance level, that is, a lower significance level, for each pairwise test, so that the overall Type 1 error rate for the series of tests you have to do can still be held at a low rate.
-
+That is, we'll use a "family" error rate, and then distribute that level to each of the tests we are performing. The "family" error rate specifies an overall Type I error rate we are willing to have for **all** of tests you wish to perform. 
 
 
 ### Multiple comparisons
 
+Testing many pairs of groups is called multiple comparisons. 
 
-> - Testing many pairs of groups is called multiple comparisons
-> - The Bonferroni correction suggests that a more stringent significance level is more appropriate for these tests 
->     - Adjust $\alpha$ by the number of comparisons being considered 
->     - $\alpha^\star = \frac{\alpha}{K}$, where $K = \frac{k (k-1)}{2}$ 
+A common modification we use when doing multiple comparisons is the Bonferroni correction. This correction fixes a "family" error rate which then transfers to a more stringent significance level for each of the pairwise tests. 
 
-Testing many pairs of groups is called multiple comparisons
+More specifically, we will adjust our "family" $\alpha$ by the number of comparisons we are doing. 
 
-and a common modification we use when doing multiple comparisons is the Bonferroni correction which uses a more stringent significance level for each of the pairwise tests
+The Bonferroni corrected significance level can be calculated as the original significance level ($\alpha$) divided by the number of pairwise comparisons to be carried out. 
 
-more specifically, we adjust our alpha by the number of comparisons we have to do
+If we think back to our days in Algebra, we can calculate the total number of tests using combinatorics. Specifically, for $k$ groups we will have ${k \choose 2}$ possible pairwise tests. This number of tests can be calculated as $\frac{k \cdot (k - 1)}{2}$, where k is the number of groups in the ANOVA.
 
-the Bonferroni corrected significance level can be calculated as the original significance level divided by the number of pairwise comparisons to be carried out. This number can be calculated as k times k-1 divided by 2, where k is the number of groups in the ANOVA.
+> - Testing many different pairs of groups is called multiple comparisons
+> - Due to the inflated Type I error rate, a correction for the significance level is needed 
+>     - The Bonferroni correction uses a more stringent significance level  
+>     - It adjusts $\alpha$ by the number of comparisons being considered 
+>     - The new $\alpha$ is $\alpha^\star = \frac{\alpha}{K}$, where $K = \frac{k (k-1)}{2}$ 
 
-
-
-### Pairwise comparisons
-
-
-> - Constant variance $\rightarrow$ re-think standard error and degrees of freedom: Use consistent standard error and degrees of freedom for all tests
-> - Compare the p-values from each test to the modified significance level
-
-
-There are a couple other considerations for these multiple comparisons following anova.
-
-First is related to the constant variance condition of ANOVA. Since to do the ANOVA in the first place this condition must be satisfied, we need to re-think the standard error and the degrees of freedom to be used in the multiple comparisons tests.
-
-And of course, since we now have a new modified significance level, we compare the resulting p-values to this significance level.
 
 
 Now it's your turn.
 
-### Calculate alpha*
+### Calculate $\alpha^*$
 
-Which of the following is the correct modified significance value for the post hoc tests associated with ANOVA for evaluating whether there are differences between the average vocabulary scores across social classes?
+Which of the following is the correct modified significance value for the post hoc tests associated with ANOVA for evaluating which of the self-identified social classes have different average vocabulary scores?
 
 There are 4 social classes, and the original significance level was 5%.
 
-*Hint* For $k$ levels, there are $k * (k - 1) / 2$ pairwise comparisons.
+*Hint:* For $k$ groups, there are $k \cdot (k - 1) / 2$ pairwise comparisons.
 
 ```{r quiz_3}
 question("",
@@ -509,51 +565,82 @@ question("",
 
 ### Compare pairwise means
 
-Compare means of vocabulary scores using the `pairwise.t.test()` function for all pairings of social classes.
+We can compute all of the pairwise $t$-tests for our 4 social classes using the `pairwise.t.test()` function. This function is a bit different than other functions we have used, in that it expects for the variables to be extracted from the dataframe when they are input. This is different from our "usual" workflow where we "pipe" data from the dataset into the function. 
+
+There are two ways to handle this,  
+
+1. Extract the columns you are interested in using a `$` and use as the inputs to the `pairwise.t.test()` function.  
+2. Use a modified pipe operator to extract the columns (`%$%`), when piping the data into the `pairwise.t.test()` function. 
+
+We will present the modified pipe operator option, but both methods will be displayed in the solution. 
+
+Additionally, the `pairwise.t.test()` function takes three main inputs,   
+
+1. the response variable (input as `x`)
+2. the grouping variable (input as `g`)
+3. the adjustment method to use (input as `p.adjust.method`) -- there are other adjustment methods, but in this exercise we will focus on the `"bonferroni"` adjustment 
+
+### 
+
+For this exercise, you are to conduct a pairwise t-test on vocabulary scores and social class.
+
+- Use the `pairwise.t.test()` function to obtain the pairwise $t$-tests. 
+- Set the `p.adjust.method` to `"Bonferroni"` to obtain the Bonferroni corrected p-values.
+- Tidy the resulting table. 
+- Compare the adjusted p-values to the un-adjusted p-values.
 
 
-
-- Conduct a pairwise t-test on vocabulary scores and social class. Set `p.adjust.method` to `"none"` (*we'll adjust the significance level, not the p-value*).
-- Tidy the result.
-- *Do the data provide convincing evidence of a difference in the average vocabulary scores of those who self identified as middle class and those who self identified as lower class?*
-
-
-```{r vocabulary_4-setup, include=FALSE}
-
-```
-
-```{r vocabulary_4, exercise=TRUE}
+```{r vocabulary_5, exercise=TRUE}
 # Run a pairwise t-test on wordsum and class, without adjustment
-t_test_results <- ___
+t_test_results <- gss %$%  
+  pairwise.t.test(x = ___, g = ___, p.adjust.method = "___")
+
 
 # Tidy the result
-___
+tidy(___)
+
+## Compare with un-adjusted pairwise t-tests
+gss %$% 
+  pairwise.t.test(wordsum, class, p.adjust.method = "none")
 ```
 
 <div id="vocabulary_4-hint">
 **Hint:** 
-- Call `pairwise.t.test()` passing the `wordsum` and `class` columns of `gss`, and setting `p.adjust.method` to `"none"`.
-- You can use dollar notation, `dataframe$column`, to get the appropriate columns.
-- Call `tidy()`, passing the t-test results.
+- Use `wordsum` as `x`, `class` as `g`, and set `p.adjust.method` to `"bonferroni"`.
+- Call `tidy()`, passing `t_test_results`.
 </div>
 
-```{r vocabulary_4-solution}
+```{r vocabulary_5-solution}
 # Run a pairwise t-test on wordsum and class, without adjustment
-t_test_results <- pairwise.t.test(gss$wordsum, gss$class, p.adjust.method = "none")
+t_test_results <- gss %$%  
+  pairwise.t.test(x = wordsum, g = class, p.adjust.method = "bonferroni")
+
+## Alternative method 
+t_test_results <- pairwise.t.test(gss$wordsum, gss$class, p.adjust.method = "bonferroni")
+
 
 # Tidy the result
-tidy(t_test_results)
+tidy(___)
+
+## Compare with un-adjusted pairwise t-tests
+gss %$% 
+  pairwise.t.test(wordsum, class, p.adjust.method = "none") %>% 
+  tidy()
+
 ```
 
 ### 
 
-Did you remember to compare your resulting p-value to the *modified* significance level?
+
+Do the data provide convincing evidence of a difference in the average vocabulary scores of those who self-identified as middle class and those who self-identified as lower class?
+
+For which of the pairwise comparisons would you conclude that there is a "significant" difference between the group means?
 
 ## Congratulations!
 
-You have successfully completed Lesson 2 in Tutorial 7: Inference for Numerical Responses.  
+You have successfully completed Lesson 4 in Tutorial 7: Comparing many means.  
 
-You should now have a very good understanding of statistical inference for numerical data. In this tutorial you have learned about simulation based and central limit theorem based methods for doing statistical inference for a single numerical variable or for evaluating bivariate relationships between a numerical variable and a categorical variable, both with only two levels and with multiple levels. You have also been introduced to a "tidy" way of conducting such analyses using the infer package as well as packages from the tidyverse.
+You should now have a very good understanding of statistical inference for numerical data. In this tutorial you have learned about parametric procedures for conducing an analysis of variance (ANOVA). Specifically, you should now be familiar with the concepts of variability within and between groups, the $F$-distribution, and multiple comparison procedures. 
 
 What's next?
 
@@ -563,10 +650,10 @@ What's next?
 
 `r emo::ji("one")` [Tutorial 7 - Lesson 1: Bootstrapping for estimating a parameter](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-01/)
 
-`r emo::ji("one")` [Tutorial 7 - Lesson 2: Introducing the t-distribution](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-02/)
+`r emo::ji("two")` [Tutorial 7 - Lesson 2: Introducing the t-distribution](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-02/)
 
-`r emo::ji("one")` [Tutorial 7 - Lesson 3: Inference for difference in two parameters](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-03/)
+`r emo::ji("three")` [Tutorial 7 - Lesson 3: Inference for difference in two parameters](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-03/)
 
-`r emo::ji("one")` [Tutorial 7 - Lesson 4: Comparing many means](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-04/)
+`r emo::ji("four")` [Tutorial 7 - Lesson 4: Comparing many means](https://openintro.shinyapps.io/ims-07-inference-for-numerical-responses-04/)
 
 `r emo::ji("open_book")` [Learn more at Introduction to Modern Statistics](http://openintro-ims.netlify.app/)


### PR DESCRIPTION
Similar changes to the Inference tutorial: 

- changed from `t.test()` to `t_test()` 
- use `get_p_value()` to find p-value instead of `summarize()` 

Note: the original example with overtime worked was not compatible, as that variable was not in the `gss` dataframe. This example has been changed to estimating the number of hours worked, and comparing the `acs12` confidence interval to the `gss` interval. 