### PR TITLE
add `common_cyl` to ex2 setup

### DIFF
--- a/02-summarizing-and-visualizing-data/02-lesson/02-02-lesson.Rmd
+++ b/02-summarizing-and-visualizing-data/02-lesson/02-02-lesson.Rmd
@@ -775,7 +775,7 @@ Thus, the `%in%` operator always comes with the `c()` function, which makes the 
 
 Putting this all together, our code looks like: 
 
-```{r, echo = TRUE}
+```{r, ex2-setup, echo = TRUE}
 common_cyl <- cars %>%
   filter(ncyl %in% c(4, 6, 8))
 ```


### PR DESCRIPTION
The ex2 exercise chunk generates the error message: "object `common_cyl` not found" because the nameless chunk, where the new dataset `common_cyl` is generated, does not function as a setup chunk for exercise ex2.