### PR TITLE
convert the div hint to standard text and put it before exercise chunk

### DIFF
--- a/02-summarizing-and-visualizing-data/04-lesson/02-04-lesson.Rmd
+++ b/02-summarizing-and-visualizing-data/04-lesson/02-04-lesson.Rmd
@@ -166,6 +166,8 @@ The `email` dataset is still available in your workspace.
 - Construct an appropriate plot to visualize the association between the same two variables, adding in a log-transformation step if necessary.
 - If you decide to use a log transformation, remember that `log(0)` is `-Inf` in R, which isn't a very useful value! You can get around this by adding a small number (like `0.01`) to the quantity inside the `log()` function. This way, your value is never zero. This small shift to the right won't affect your results.
 
+**Hint:** Take a look at how we calculated the summary statistics for `num_char` with the `median()` and `IQR()` functions in the `summarize()` call earlier.
+
 ```{r ex2, exercise = TRUE}
 # Compute center and spread for exclaim_mess by spam
 
@@ -178,9 +180,8 @@ The `email` dataset is still available in your workspace.
 
 ```
 
-<div id="ex2-hint">
-**Hint:** Take a look at how we calculated the summary statistics for `num_char` with the `median()` and `IQR()` functions in the `summarize()` call earlier.
-</div>
+
+
 
 ```{r ex2-solution}
 # Compute center and spread for exclaim_mess by spam


### PR DESCRIPTION
At the moment [you can't mix markdown and R Markdown](https://github.com/rstudio/learnr/issues/421). Therefore, the solution could not be seen by students whenever there is a div hint.

The solution to progressively reveal hints does not work well as the solution chunk is very long, and the hint windows take on the same size, even if their text is much shorter.

So my suggestion is to write the hint as regular text before the exercise chunk. I think this is justified as it is a very general hint which does not spoil the main challenges of the exercise task.  