### PR TITLE
change link address

### DIFF
--- a/01-data/01-lesson/01-01-lesson.Rmd
+++ b/01-data/01-lesson/01-01-lesson.Rmd
@@ -679,7 +679,7 @@ What's next?
 
 `r emo::ji("ledger")` [Full list of tutorials supporting OpenIntro::Introduction to Modern Statistics](https://openintrostat.github.io/ims-tutorials/)
 
-`r emo::ji("spiral_notepad")` [Tutorial 1: Getting Started with Data](https://openintrostat.github.io/ims-tutorials/01-getting-started-with-data/)
+`r emo::ji("spiral_notepad")` [Tutorial 1: Getting Started with Data](https://openintrostat.github.io/ims-tutorials/01-data/)
 
 `r emo::ji("one")` [Tutorial 1 - Lesson 1: Language of data](https://openintro.shinyapps.io/ims-01-getting-started-with-data-01/)
 


### PR DESCRIPTION
The URL https://openintrostat.github.io/ims-tutorials/01-getting-started-with-data/ does not work (anymore).

I noticed that there are two addresses to the same content of the tutorials.

1. One URL has the pattern
- https://openintro.shinyapps.io/ims-01-getting-started-with-data-01/
- …data-02
- …data-03 etc.

This is the URL from the final section of the tutorial (congratulation section)

2. Another URL has the pattern
- https://openintro.shinyapps.io/ims-01-data-01/
- …data-02
- …data-03 etc.
This is the (newer) URL from the tutorial description.