### PR TITLE
turn "echo=True, eval=FALSE" chunks to "exercise=TRUE" 

### DIFF
--- a/02-explore/01-lesson/02-01-lesson.Rmd
+++ b/02-explore/01-lesson/02-01-lesson.Rmd
@@ -49,22 +49,26 @@ Let's get started.
 
 In this tutorial, you'll be exploring data from a wide range of contexts. The first dataset comes from comic books. Two publishers, Marvel and DC, have created a host of superheroes that have made their way into popular culture. You're probably familiar with Batman and Spiderman, but what about Mor the Mighty?
 
-The comics dataset has information on all comic characters that have been introduced by DC and Marvel. If we type the name of the dataset at the console, we get the first few rows and columns. Here we see that each row, or case, is a different character and each column, or variable, is a different observation made about that character. At the top the output tell us the dimensions of this dataset: over 23,000 cases and 11 variables. Right under the variable names, we see that the first three variables are characters, or the `chr` data type. These are variables that we could potentially consider categorical, as they all have a finite number of levels. The first case in the dataset is Peter Parker, alias: Spiderman, where his alias and character name are included in the first variable `name`. The second column, `id`, shows that Peter Parker's personal identity is kept secret, and the third column tell us that his `align`ment is good; that he's a superhero, not a super villain. If you scroll the table to the right side, you will see several additional variables, including eye color and hair color, almost all of which are also characters.
-
-```{r comics, echo=FALSE}
-comics 
+The comics dataset has information on all comic characters that have been introduced by DC and Marvel. Let's take take a look at the dataset and explore it. 
+```{r comics, exercise=TRUE}
+glimpse(comics)
 ```
 
-We can learn the different values of a particular character variable by using the `distinct()` function. It's clear that the alignment variable can be "good" or "neutral", but what other values are possible? Here, we pipe the `comics` data into the `distinct()` function, and then insert the `align` column into the `distinct()` function. Inspecting the resulting table, we learn that there are in fact four possible alignments, "Good", "Bad", "Neutral", and "Reformed criminals". 
 
-```{r levels, echo=TRUE}
+At the top the output tell us the dimensions of this dataset: over 15,000 cases and 11 variables. With one exception (appearances) we see that that all variables are characters, or of the `chr` data type. These are variables that we could potentially consider categorical, as they all have a finite number of levels. 
+
+The first case in the dataset is Peter Parker, alias: Spiderman, where his alias and character name are included in the first variable `name`. The second column, `id`, shows that Peter Parker's personal identity is kept secret, and the third column tell us that his `align`ment is good; that he's a superhero, not a super villain.
+
+We can learn the different values of a particular character variable by using the `distinct()` function. It's clear that the alignment variable can be "good" or "neutral", but what other values are possible? Here, we pipe the `comics` data into the `distinct()` function, and then insert the `align` column into the `distinct()` function. 
+
+```{r levels, exercise=TRUE}
 comics %>% 
   distinct(align)
 ```
 
-Good thing we checked that! If we do the same for identity, we learn that there are four possible identities.
+Inspecting the resulting table, we learn that there are in fact four possible alignments, "Good", "Bad", "Neutral", and "Reformed criminals". Good thing we checked that! If we do the same for identity, we learn that there are four possible identities.
 
-```{r levels2, echo=TRUE}
+```{r levels2, exercise=TRUE}
 comics %>% 
   distinct(id)
 ```
@@ -73,15 +77,17 @@ A common way to represent the number of cases that fall into each combination of
 
 1. use the `count()` function to count the number of observations
 2. specify the variables you are interested in **inside** the `count()` function
-3. pivot the table from its current "long" format to a "wide" format using the `pivot_wider()` function 
 
-This is what the process looks like:
 
-```{r levels3, echo=TRUE, eval = FALSE}
+```{r levels3, exercise=TRUE}
 # to get the long table
 comics %>% 
   count(align, id)
-  
+```
+
+3. pivot the table from its current "long" format to a "wide" format using the `pivot_wider()` function 
+
+```{r levels4, exercise=TRUE}
 # to get a wider table
 comics %>% 
   count(align, id) %>% 
@@ -92,15 +98,7 @@ The first two steps should look familiar to you, but the third step is a bit ove
 
 We want for the values of `align` to be in the rows and the values of `id` to be in the columns. We can use the `pivot_wider()` function to "pivot" our table so that it has this form, by moving the `id` variable to the columns, and filling the values of the table with the count variable (`n`). The `names_from` argument tells R where the names of the new columns are coming from (i.e. what variable), and the `values_from` argument tells R where the values in the table are coming from. Here, the values we want in our table are stored as a variable labeled `n` in our table. 
 
-```{r level3out, echo=FALSE}
-comics %>% 
-  count(align, id) %>% 
-  pivot_wider(names_from = id, values_from = n) %>% 
-  kable() %>%
-  kable_styling(bootstrap_options = "striped", full_width = F, position = "left")       
-```
-
-The output tells us that the most common category, at a count of 4493, was "Bad" characters with "Secret" identities.
+The output tells us that the most common category, at a count of 4352, was "Bad" characters with "Secret" identities.
 
 While tables of counts can be useful, you can get the bigger picture by translating these counts into a graphic. The graphics that you'll be making in this tutorial utilize the **ggplot2** package, which you got a glimpse of in the previous tutorial. Every ggplot requires that you specify three elements: 
 
@@ -119,24 +117,19 @@ ggplot(data = [DATASET], aes(x = [X VARIABLE],
 
 Here, we're interested in the relationship between two categorical variables, which is represented well by a stacked bar chart. In a bar chart, we plot the counts or frequencies of different levels of a categorical variable, by specifying the categorical variable we want to be on the x-axis, and adding a `geom_bar()` layer to the plot. 
 
-```{r formula2, eval=FALSE, include=TRUE}
+```{r formula2, exercise=TRUE}
 ggplot(comics, aes(x = id)) +
   geom_bar() 
 ```
 
 A stacked bar chart adds another layer to the plot, by dividing each bar into different levels of another variable. This coloring of the bars comes from adding a second categorical variable into the `fill` argument of the `aes()` function. This looks something like this: 
 
-```{r formula3, eval=FALSE, include=TRUE}
+```{r formula3, exercise=TRUE}
 ggplot(comics, aes(x = id, fill = align)) +
   geom_bar() 
 ```
 
 Let's look carefully at how this is constructed: each colored bar segment actually corresponds to a count in our table, with the x-axis and the fill color indicating the category being plotted. Several things pop out, like the fact that there are very few characters whose identities are unknown (since it's nearly flat). The single largest bar segment corresponds to the most common category: characters with secret identities that are also bad. We can look across the identity types and realize that bad is not always the largest category. This indicates that there is indeed an association between alignment and identity.
-
-```{r bar, echo=TRUE}
-ggplot(comics, aes(x = id, fill = align)) +
-    geom_bar()
-```
 
 That should be enough to get started. Now it's your turn to start exploring the data.
 


### PR DESCRIPTION
The many changes result from a different educational approach: Instead, to present text, I suggest changing the options of the R chunks from "echo=TRUE" sometimes even combined with "eval=FALSE" to "exercise=TRUE" chunks so students have to click the "Run Code" button themselves. To support the exploring approach, I had to separate some code lines into different chunks and rewrite some text passages.

This long first section of the file uses just chunks with "echo=TRUE" so students can only read. I suggest turning these chunks into "exercise=TRUE" so students can explore themselves. This different approach also requires some text changes.

I also changed the reported figures as the original comics dataset was changed with `droplevels()` in the R setup chunk. 
****
Please take this just as a suggestion. If you decide not to follow it, you should make two changes anyway:

1. Chance 23,000 to 15,000 and 4493 to 4352
2. Replace the chunks with the label 'comics' from 'comics" to 'glimpse comics' and the following text accordingly. Why: The next section will use the glimpse function, and besides memory concern in the standard  `learnr`-environment, only 10,000 records are shown.