### PR TITLE
check result more specifically

### DIFF
--- a/02-explore/01-lesson/02-01-lesson.Rmd
+++ b/02-explore/01-lesson/02-01-lesson.Rmd
@@ -262,6 +262,7 @@ The contingency table from the last exercise is available in your workspace as `
 2. use `filter()` to filter out all rows of `comics` with that level
 3. use `droplevels()` to drop the unused levels from the dataframe 
 4. save the simplified dataset as `comics_filtered`
+5. check if the unused level of `align` is dropped
 
 
 ```{r ex2-setup}
@@ -280,7 +281,8 @@ comics_filtered <- ___ %>%
   ___()
 
 # See the result
- comics_filtered
+ comics_filtered %>%
+   ___(align)
 
 ```
 
@@ -294,7 +296,8 @@ comics_filtered <- comics %>%
   droplevels()
 
 # See the result
-comics_filtered
+comics_filtered %>%
+  distinct(align)
 
 ```
 


### PR DESCRIPTION
To display the complete simplified dataset `comics_filtered` does not show the difference immediately. I suggest checking if the unused level is dropped successfully.
***
Not sure if the markdown hint about `!=` is a good idea. As it is already present in the task guidance, it is not asked for, but it destroys the step-by-step guidance of the solution.