### PR TITLE
For correct masking in exercise chunk refer in setup chunk to package `datasets`

### DIFF
--- a/03-model/02-lesson/03-02-lesson.Rmd
+++ b/03-model/02-lesson/03-02-lesson.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(echo = FALSE,
                       message = FALSE, 
                       warning = FALSE)
 
-anscombe <- anscombe %>%
+anscombe <- datasets::anscombe %>%
   mutate(id = 1:nrow(.)) %>%
   gather(key = "key", value = "val", -id) %>%
   separate(key, into = c("variable", "set"), sep = 1) %>%


### PR DESCRIPTION
Without the package name the exercise at the first [#section-your-turn](https://openintro.shinyapps.io/ims-03-introduction-to-linear-models-02/#section-your-turn) fails with the following error: 

> Problem with `summarise()` input `correlation_between_x_and_y`. ✖ 'x' must be numeric ℹ Input `correlation_between_x_and_y` is `cor(x, y)`. ℹ The error occurred in group 1: set = "".

I tracked the problem to a masking problem: In R chunks, the original dataset "anscombe" is masked (hidden) by the new global modified variable with the same name. But this is not the case in R exercise chunks. (At least that is my explication…)

Alternatively, one could generate a variable with a different name (e.g., `anscombe_mod <- anscombe`) and change all those chunks (R and exercise chunks) where it is used. I have tried this too, but the above solution is more elegant.