### PR TITLE
Add missing links for lessons 6-10 to TOC

### DIFF
--- a/03-model/01-lesson/03-01-lesson.Rmd
+++ b/03-model/01-lesson/03-01-lesson.Rmd
@@ -583,4 +583,14 @@ What's next?
 
 `r emo::ji("five")` [Tutorial 3 - Lesson 5: Model fit](https://openintro.shinyapps.io/ims-03-introduction-to-linear-models-05/)
 
+`r emo::ji("six")` [Tutorial 3 - Lesson 6: Parallel slopes](https://openintro.shinyapps.io/ims-03-model-06/)
+
+`r emo::ji("seven")` [Tutorial 3 - Lesson 7: Evaluating and extending parallel slopes model](https://openintro.shinyapps.io/ims-03-model-07/)
+
+`r emo::ji("eight")` [Tutorial 3 - Lesson 8: Multiple regression](https://openintro.shinyapps.io/ims-03-model-08/)
+
+`r emo::ji("nine")` [Tutorial 3 - Lesson 9: Logistic regression](https://openintro.shinyapps.io/ims-03-model-09/)
+
+🔟 [Tutorial 3 - Lesson 10: Case study: Italian restaurants in NYC](https://openintro.shinyapps.io/ims-03-model-10/)
+
 `r emo::ji("open_book")` [Learn more at Introduction to Modern Statistics](http://openintro-ims.netlify.app/)

--- a/03-model/01-lesson/03-01-lesson.Rmd
+++ b/03-model/01-lesson/03-01-lesson.Rmd
@@ -591,6 +591,6 @@ What's next?
 
 `r emo::ji("nine")` [Tutorial 3 - Lesson 9: Logistic regression](https://openintro.shinyapps.io/ims-03-model-09/)
 
-🔟 [Tutorial 3 - Lesson 10: Case study: Italian restaurants in NYC](https://openintro.shinyapps.io/ims-03-model-10/)
+`r emo::ji("keycap_ten")` [Tutorial 3 - Lesson 10: Case study: Italian restaurants in NYC](https://openintro.shinyapps.io/ims-03-model-10/)
 
 `r emo::ji("open_book")` [Learn more at Introduction to Modern Statistics](http://openintro-ims.netlify.app/)


### PR DESCRIPTION
Tutorial #3 now has 10 lessons. Provide links to them. This has to be done for all lessons in the tutorial on regression modeling (copy & paste).

I will provide the next few days also the changes for the book to this issue.

NOTE: I could not manage the R code for the emoji of lesson 10 and have it included as an inline icon. `r emo:ji("ten")` displays a 10 o'clock watch in my installation.

NOTE: Cannot call lesson 6  because of a missing graph in a knitr::include_graphics() command. (lines 457-458). I think I have found the problem: the graphic of chunk "mpg-data-parallel" has to be saved + called. If this is correct, a PR to this issue will follow in a few days.