### PR TITLE
adapt link address to new tutorial structure

### DIFF
--- a/03-model/06-lesson/03-06-lesson.Rmd
+++ b/03-model/06-lesson/03-06-lesson.Rmd
@@ -454,7 +454,7 @@ Math isn't everyone's cup of tea, and while this doesn't make it any less import
 A simple linear regression model can be visualized as a line through this data space.
 
 ```{r}
-knitr::include_graphics("04-01-lesson_files/figure-html/mpg-data-parallel-1.png")
+knitr::include_graphics("03-06-lesson_files/figure-html/mpg-data-parallel-1.png")
 ```
 
 


### PR DESCRIPTION
Calling Lesson 6 resulted into an error messages: 

> An error has occurred
> The application failed to start: exited unexpectedly with code 1
> processing file: 03-06-lesson.Rmd
> Quitting from lines 457-458 (03-06-lesson.Rmd) 
> Error in value[[3L]](cond) : 
>  Cannot find the file(s): "04-01-lesson_files/figure-html/mpg-data-parallel-1.png"
> Calls: local ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>
> Execution halted

The URL from `knitr::include_graphics` needed to be adapted to the new tutorial structure. (This is the first of the promised changes I mentioned in PR #84).