### PR TITLE
Change feedback of wrong answers.

### DIFF
--- a/03-model/04-lesson/03-04-lesson.Rmd
+++ b/03-model/04-lesson/03-04-lesson.Rmd
@@ -146,7 +146,7 @@ question("Which of the following mistakes in interpretation has the politician m
   answer("Switching the role of the response and explanatory variables."),
   answer("Confusing percentage change with percentage point change."),
   answer("All of the above.", correct = TRUE),
-  answer("None of the above.", message = "A little skepticism would be good here! The politician has made more than one mistake in interpreting the relationship."),
+  incorrect = "Only partly correct: The politician has made more mistakes in interpreting the relationship.",
   allow_retry = TRUE
 )
 ```

--- a/03-model/06-lesson/03-06-lesson.Rmd
+++ b/03-model/06-lesson/03-06-lesson.Rmd
@@ -454,7 +454,7 @@ Math isn't everyone's cup of tea, and while this doesn't make it any less import
 A simple linear regression model can be visualized as a line through this data space.
 
 ```{r}
-knitr::include_graphics("04-01-lesson_files/figure-html/mpg-data-parallel-1.png")
+knitr::include_graphics("03-06-lesson_files/figure-html/mpg-data-parallel-1.png")
 ```
 
 


### PR DESCRIPTION
In the original version, students get by choosing the options 1, 2, or 3 the feedback "Incorrect". But the selection itself is correct; even it is only partly correct.

Besides, I had to delete "None of the above" because the correct answer "All of the above" IS above this last option.

[Technically, one would formulate this question as a Multiple-Choice question (symbolized with checkboxes instead of radio boxes). But of design errors in the `learnr` package, you cannot provide correct feedback for all options AND allow for retrying the question. (I plan to report this problem in the question design to RStudio.)

(Sorry for the second file change. I do not know why this appeared here. We have already corrected this wrong link address and merged it successfully. --- I do not know how to remove this part of this PR after it is already committed.