### PR TITLE
Bugfix for 04/04. Needed objects defined in the lesson setup. 

### DIFF
--- a/04-foundations/04-lesson/04-04-lesson.Rmd
+++ b/04-foundations/04-lesson/04-04-lesson.Rmd
@@ -27,10 +27,24 @@ knitr::opts_chunk$set(fig.align = "center",
                       warning = FALSE)
 
 # data prep --------------------------------------------------------------------
+set.seed(47)
 
 all_polls <- read_rds("data/all_polls.rds")
 
-set.seed(47)
+one_poll <- all_polls |>
+  filter(poll == 1) |>
+  select(vote)
+
+p_hat <- one_poll |>
+  summarize(mean(vote == "yes")) |>
+  pull()
+
+# Bootstrap to find the SE of p-hat: one_poll_boot
+one_poll_boot <- one_poll |>
+  specify(response = vote, success = "yes") |>
+  generate(reps = 1000, type = "bootstrap") |> 
+  calculate(stat = "prop")
+
 ```
 
 ## Parameters and confidence intervals


### PR DESCRIPTION
I have defined the one_poll, one_poll_boot and p_hat objects in the lesson setup so that they can be accessed when needed in the various exercises.

The tutorial claims that "one_poll, ... one_poll_boot,... and p_hat are available in your workspace". However, they are not available in the workspace and it causes many errors. For example, exercises bootstrap_percentile_2 and bootstrap_percentile_3 throw an error because "object 'one_poll_boot' not found".

As a side note: the one_poll_boot object is created at least 7 times in this lesson, likely as partial patches to the object not being defined in the initial lesson setup.