### PR TITLE
Fixed error in 02-01:

### DIFF
--- a/02-explore/01-lesson/02-01-lesson.Rmd
+++ b/02-explore/01-lesson/02-01-lesson.Rmd
@@ -787,7 +787,7 @@ The pie chart is a common way to display categorical data where the size of the 
 If we represent this data using a barchart the answer is obvious: the proportion of public is greater. For that reason, it's generally a good idea to stick to barcharts.
 
 ```{r pie, echo=FALSE, fig.height=3, fig.width=6, cache = TRUE}
-plot1 <- ggplot(comics |> group_by(id)|>count, aes(x = "", y = n, fill = id))+
+plot1 <- ggplot(comics |> group_by(id)|>count(), aes(x = "", y = n, fill = id))+
  geom_bar(stat="identity", width=1)+
  coord_polar("y", start=0) +
    theme(axis.text = element_blank(),


### PR DESCRIPTION
"The pipe operator requires a function call as RHS" in chunk pie caused by using "|>count" instead of "|>count()"
in 02-01-lesson.Rmd