### PR TITLE
potential solution to p-value discrepancy (tutorial 4.3)

### DIFF
--- a/04-foundations/03-lesson/04-03-lesson.Rmd
+++ b/04-foundations/03-lesson/04-03-lesson.Rmd
@@ -435,10 +435,6 @@ The permuted dataset and the original observed statistic are available in your w
 - As an alternative way to calculate the p-value, use `summarize()` and `mean()` to find the proportion of times the permuted differences in `opp_perm` (called `stat`) are less than or equal to the observed difference (called `diff_obs`).
 - You can test your knowledge by trying out: `direction = "greater"`, `direction = "two_sided"`, and `direction = "less"` before submitting your answer to both `visualize()` and `get_p_value()`.
 
-```{r summarizing_opportunity_cost-setup}
-opp_perm <- read_rds("data/opp_perm2.rds") 
-```
-
 ```{r summarizing_opportunity_cost, exercise=TRUE}
 # Visualize the statistic 
 opp_perm |>


### PR DESCRIPTION
following from closed issue #115  there's still a discrepancy between the `summarizing_opportunity_cost-solution` p-values and the ones reported in the `opportunity_cost_conclusion` and `mc1` chunks. it appears to be due to the exercise-specific definition of `opp_perm` which has a p-value of 0.017 whereas the initial `setup` chunk definition of `opp_perm` has the calculated p-value of 0.007.