### PR TITLE
Tutorial 01-01: hash generation is inconsistent with all other tutorials. 

### DIFF
--- a/01-data/01-lesson/01-01-lesson.Rmd
+++ b/01-data/01-lesson/01-01-lesson.Rmd
@@ -788,12 +788,10 @@ What's next?
 
 ## Submit
 
-```{r context="server"}
-learnrhash::encoder_logic(strip_output = TRUE)
+```{r, echo=FALSE, context="server"}
+encoder_logic()
 ```
 
 ```{r encode, echo=FALSE}
-learnrhash::encoder_ui(
-  ui_before = "If you have completed this tutorial and are happy with all of your answers, please click the button below to generate a hash of your answers."
-)
+learnrhash::encoder_ui(ui_before = hash_encoder_ui)
 ```


### PR DESCRIPTION
Tutorial 01-01: changed use of learnrhash::encoder_logic to the one defined in the in the R folder. It now matches the other tutorials.