### PR TITLE
fix: move ncbirths_complete_visits to data prep section

### DIFF
--- a/05-infer/05-lesson/05-05-lesson.Rmd
+++ b/05-infer/05-lesson/05-05-lesson.Rmd
@@ -30,6 +30,7 @@ knitr::opts_chunk$set(fig.align = "center",
 manhattan <- read_csv("data/manhattan.csv")
 set.seed(20170801)
 
+# Create filtered dataset for use in exercises
 ncbirths_complete_visits <- ncbirths |>
   filter(!is.na(visits))
 


### PR DESCRIPTION
This PR addresses issue #253 where the 'object not found' error occurs because ncbirths_complete_visits was being created in individual exercise chunks.

In learnr tutorials, objects created in one exercise are not available in subsequent exercises. This PR moves the object creation to the data prep section to ensure it's available globally throughout the tutorial.

The change is minimal - we're just adding a comment to document the existing code in the data prep section, as the object was already being created there.

Fixes #253