### PR TITLE
fix: make objects accessible in exercise 5 by adding setup chunk name

### DIFF
--- a/03-model/09-lesson/03-09-lesson.Rmd
+++ b/03-model/09-lesson/03-09-lesson.Rmd
@@ -468,7 +468,7 @@ Note that the left hand side is the expected probability $y$ of being accepted t
 
 
 
-```{r}
+```{r ex5-setup}
 mod <- glm(Acceptance ~ GPA, data = MedGPA, family = binomial)
 
 gpa_bins <- quantile(MedGPA$GPA, probs = 0:6/6)


### PR DESCRIPTION
This PR addresses issue #268 by making objects accessible in exercise 5 of tutorial 9.

The setup chunk containing 'mod' and 'gpa_bins' objects was previously unnamed, which meant these objects were not available in the exercise chunk, causing 'object not found' errors. Adding the name 'ex5-setup' makes these objects accessible in the exercise.

Changes made:
- Added chunk name 'ex5-setup' to the setup chunk in tutorial 9 (03-model/09-lesson/03-09-lesson.Rmd) to make objects available in exercise 5

Fixes #268