### PR TITLE
fix: make hrly_pay accessible in exercise 5

### DIFF
--- a/05-infer/07-lesson/05-07-lesson.Rmd
+++ b/05-infer/07-lesson/05-07-lesson.Rmd
@@ -1089,7 +1089,7 @@ The `acs12_complete_hrlypay_citizen` is already loaded for you.
 
 **Remember** the `t_test()` function behaves similarly to the `calculate()` function! 
 
-```{r citizens_5-setup, include = FALSE}
+```{r citizens_5-setup}
 ## Complete hourly pay and citizenship 
 acs12_complete_hrlypay_citizen <- acs12 |>
   mutate(hrly_pay = income / (hrs_work * 52)) |>

--- a/05-infer/07-lesson/05-07-lesson.Rmd
+++ b/05-infer/07-lesson/05-07-lesson.Rmd
@@ -842,12 +842,12 @@ In this lesson we return to the American Community Survey data and compare avera
 ### A (more) standard measure of pay
 
 
-Instead of comparing average annual `income`, let's compare average `hrly_rate`. We'll calculate this by:
+Instead of comparing average annual `income`, let's compare average `hrly_pay`. We'll calculate this by:
 
 > - assuming there is 52 weeks in a year 
-> - using the formula `hrly_rate = income / (hrs_work * 52)`
+> - using the formula `hrly_pay = income / (hrs_work * 52)`
 
-One obvious measure of pay is annual income. However instead of comparing annual incomes directly, we should adjust for the number of hours worked, and compare average hourly rates. So first, we'll create a new variable called `hrly_rate`. 
+One obvious measure of pay is annual income. However instead of comparing annual incomes directly, we should adjust for the number of hours worked, and compare average hourly rates. So first, we'll create a new variable called `hrly_pay`. 
 
 To do so we'll make the assumption that there are 52 weeks in a year, and calculate hourly rate as income divided by weekly hours times 52 weeks in the year.
 

--- a/05-infer/07-lesson/05-07-lesson.Rmd
+++ b/05-infer/07-lesson/05-07-lesson.Rmd
@@ -465,7 +465,7 @@ ncbirths_complete_habit <- ncbirths |>
 
 Next, use `specify()` and `calculate()` to calculate observed difference in mean baby `weight` between smoking habit groups. Use $\bar{x}_{nonsmoker} - \bar{x}_{smoker}$. 
 
-```{r smoking_2-setup, include = FALSE}
+```{r smoking_2-setup}
 # From previous steps
 ncbirths_complete_habit <- ncbirths |>
   filter(!is.na(habit))
@@ -505,7 +505,7 @@ Then, generate 1000 differences in means via permutation and store as `diff_mean
 - `generate()` 1000 samples via permutation.
 - `calculate()` the difference in means for each permutation. The order should have `"nonsmoker"`s first, then `"smoker"`s.
 
-```{r smoking_3-setup, include = FALSE}
+```{r smoking_3-setup}
 # From previous steps
 ncbirths_complete_habit <- ncbirths |>
   filter(!is.na(habit))
@@ -965,7 +965,7 @@ Using the `acs12` data, and specifically the variables `income`, `hrs_work`, and
 
 First, filter `acs12` for rows where hourly pay (`hrly_pay`) and U.S. citizenship status (`citizen`) are __both__ non-missing.  
 
-```{r citizens-setup, include = FALSE}
+```{r citizens-setup}
 ## Complete hourly pay and citizenship 
 acs12 <- acs12 |>
   mutate(hrly_pay = income / (hrs_work * 52)) 
@@ -997,7 +997,7 @@ Next calculate summary statistics for citizens and non-citizens. To do this, use
 1. `group_by()` citizenship status. 
 2. Use `summarize()` to calculate the mean of `hrly_pay`, the standard deviation of `hrly_pay`, and the number of observations in that citizenship group.
 
-```{r citizens_3-setup, include = FALSE}
+```{r citizens_3-setup}
 ## Complete hourly pay and citizenship 
 acs12_complete_hrlypay_citizen <- acs12 |>
   mutate(hrly_pay = income / (hrs_work * 52)) |>
@@ -1046,7 +1046,7 @@ Finally, plot a histogram of the `hrly_pay`, faceted by citizenship status.
 - Add a histogram layer with a `binwidth` of 5.
 - Facet by the `citizen`ship status. 
 
-```{r citizens_4-setup, include = FALSE}
+```{r citizens_4-setup}
 ## Complete hourly pay and citizenship 
 acs12_complete_hrlypay_citizen <- acs12 |>
   mutate(hrly_pay = income / (hrs_work * 52)) |>


### PR DESCRIPTION
This PR addresses issue #243 by making the hrly_pay variable accessible in exercise 5 of tutorial 7.

The setup chunk that creates acs12_complete_hrlypay_citizen and hrly_pay had include = FALSE, which meant these objects were not accessible in the exercise chunk. This was causing 'object not found' errors when students tried to complete the exercise.

Changes made:
- Removed include = FALSE from the citizens_5-setup chunk in 05-infer/07-lesson/05-07-lesson.Rmd to make the objects available in the exercise

Fixes #243